### PR TITLE
Let models generate their own links

### DIFF
--- a/app/campaign/routes.py
+++ b/app/campaign/routes.py
@@ -70,7 +70,7 @@ def edit(id, name=None):
 
         db.session.commit()
         flash("Campaign was changed.", "success")
-        return redirect(url_for("campaign.view", id=id, name=urlfriendly(campaign.name)))
+        return redirect(campaign.view_url())
 
     elif request.method == "GET":
         form.name.data = campaign.name

--- a/app/campaign/routes.py
+++ b/app/campaign/routes.py
@@ -1,5 +1,5 @@
 from app import db
-from app.helpers import page_title, admin_required, stretch_color, admin_or_dm_required, urlfriendly
+from app.helpers import page_title, admin_required, stretch_color, admin_or_dm_required
 from app.models import Campaign, Character
 from app.campaign import bp
 from app.campaign.forms import CampaignCreateForm, CampaignEditForm

--- a/app/character/routes.py
+++ b/app/character/routes.py
@@ -2,7 +2,7 @@ from app import db
 from app.character import bp
 from app.character.forms import CreateCharacterForm, EditCharacterForm, JournalForm
 from app.character.helpers import gen_session_choices
-from app.helpers import page_title, flash_no_permission, urlfriendly
+from app.helpers import page_title, flash_no_permission
 from app.models import Character, Party, Journal
 from datetime import datetime
 from flask import render_template, flash, redirect, url_for, jsonify, request

--- a/app/character/routes.py
+++ b/app/character/routes.py
@@ -22,7 +22,7 @@ def create():
         db.session.commit()
         flash("Character was created.", "success")
 
-        return redirect(url_for("character.view", id=char.id, name=urlfriendly(char.name)))
+        return redirect(char.view_url())
     else:
         return render_template("character/create.html", form=form, title=page_title("Add Character"))
 
@@ -61,7 +61,7 @@ def edit(id, name=None):
 
         db.session.commit()
         flash("Character changes have been saved.", "success")
-        return redirect(url_for("character.view", id=id, name=urlfriendly(char.name)))
+        return redirect(char.view_url())
     else:
         form.name.data = char.name
         form.race.data = char.race
@@ -235,4 +235,4 @@ def journal_delete(c_id, j_id, c_name=None, j_name=None):
     db.session.commit()
 
     flash("Journal entry was deleted.", "success")
-    return redirect(url_for('character.view', id=char.id, name=urlfriendly(char.name)))
+    return redirect(char.view_url())

--- a/app/character/routes.py
+++ b/app/character/routes.py
@@ -91,13 +91,13 @@ def delete(id, name=None):
         flash_no_permission()
         return redirect(url_for(no_perm))
 
-    player = char.player.username
+    player = char.player
 
     db.session.delete(char)
     db.session.commit()
 
     flash("Character was deleted.", "success")
-    return redirect(url_for('user.profile', username=player))
+    return redirect(player.view_url())
 
 @bp.route("/sidebar", methods=["GET"])
 @login_required

--- a/app/character/routes.py
+++ b/app/character/routes.py
@@ -140,7 +140,7 @@ def journal_create(c_id, c_name=None):
         db.session.commit()
         flash("Journal entry was created.", "success")
 
-        return redirect(url_for("character.journal_view", c_id=c_id, j_id=journal_entry.id, c_name=urlfriendly(char.name), j_name=urlfriendly(journal_entry.title)))
+        return redirect(journal_entry.view_url())
     else:
         # pre-select session if get-param was passed
         session_id = request.args.get("session")
@@ -188,7 +188,7 @@ def journal_edit(c_id, j_id, c_name=None, j_name=None):
 
         db.session.commit()
         flash("Journal entry was changed.", "success")
-        return redirect(url_for("character.journal_view", c_id=c_id, j_id=journal.id, c_name=urlfriendly(char.name), j_name=urlfriendly(journal.title)))
+        return redirect(journal.view_url())
     else:
         form.title.data = journal.title
         form.is_visible.data = journal.is_visible

--- a/app/event/routes.py
+++ b/app/event/routes.py
@@ -104,7 +104,7 @@ def create():
         update_timestamp(new_event.id)
 
         flash("Event was created.", "success")
-        return redirect(url_for("event.view", id=new_event.id, name=urlfriendly(new_event.name)))
+        return redirect(new_event.view_url())
     elif request.method == "GET":
         # pre-select fields if get-params were passed
         epoch_id = request.args.get("epoch")
@@ -182,7 +182,7 @@ def edit(id, name=None):
 
         flash("Event was edited.", "success")
 
-        return redirect(url_for("event.view", id=id, name=urlfriendly(event.name)))
+        return redirect(event.view_url())
     elif request.method == "GET":
         form.name.data = event.name
         form.category.data = event.category_id

--- a/app/event/routes.py
+++ b/app/event/routes.py
@@ -1,5 +1,5 @@
 from app import db
-from app.helpers import page_title, flash_no_permission, stretch_color, urlfriendly
+from app.helpers import page_title, flash_no_permission, stretch_color
 from app.models import EventSetting, Event, EventCategory, Epoch, User, Role, Moon
 from app.event import bp
 from app.event.forms import SettingsForm, EventForm, CategoryForm

--- a/app/helpers.py
+++ b/app/helpers.py
@@ -1,7 +1,6 @@
 from flask import flash, redirect, url_for
 from functools import wraps
 from app import db
-from app.models import GeneralSetting, Epoch, Month, Party, Session, Campaign
 from flask_login import current_user
 from sqlalchemy import func
 from wtforms.validators import ValidationError
@@ -31,6 +30,8 @@ def admin_or_party_required(url="index"):
     def decorator(f):
         @wraps(f)
         def decorated_function(*args, **kwargs):
+            from app.models import Party
+
             if not 'id' in kwargs:
                 flash("@admin_or_party_required was used incorrectly, contact the administrator", "danger")
                 return redirect(url_for(url))
@@ -50,6 +51,8 @@ def admin_dm_or_session_required(url="index"):
     def decorator(f):
         @wraps(f)
         def decorated_function(*args, **kwargs):
+            from app.models import Session
+
             if not 'id' in kwargs:
                 flash("@admin_or_session_required was used incorrectly, contact the administrator", "danger")
                 return redirect(url_for(url))
@@ -69,6 +72,8 @@ def admin_or_dm_required(url="index"):
     def decorator(f):
         @wraps(f)
         def decorated_function(*args, **kwargs):
+            from app.models import Campaign
+
             if not 'id' in kwargs:
                 flash("@admin_or_dm_required was used incorrectly, contact the administrator", "danger")
                 return redirect(url_for(url))
@@ -84,6 +89,7 @@ def admin_or_dm_required(url="index"):
 
 # generate the page <title>
 def page_title(dynamic_part=None):
+    from app.models import GeneralSetting
     gset = GeneralSetting.query.get(1)
 
     if not gset:
@@ -148,6 +154,8 @@ class YearPerEpochValidator(object):
         self.epoch_field = epoch_id_field_name
 
     def __call__(self, form, field):
+        from app.models import Epoch
+
         epoch_id = form._fields.get(self.epoch_field).data
 
         ep = Epoch.query.filter_by(id=epoch_id).first()
@@ -164,6 +172,7 @@ class DayPerMonthValidator(object):
         self.month_field = month_id_field_name
 
     def __call__(self, form, field):
+        from app.models import Month
         month_id = form._fields.get(self.month_field).data
 
         mo = Month.query.filter_by(id=month_id).first()
@@ -180,6 +189,7 @@ class IsDMValidator(object):
         self.campaign_field = campaign_field_name
 
     def __call__(self, form, field):
+        from app.models import Campaign
         campaign_id = form._fields.get(self.campaign_field).data
 
         campaign = Campaign.query.filter_by(id=campaign_id).first()

--- a/app/map/routes.py
+++ b/app/map/routes.py
@@ -1,5 +1,5 @@
 from app import app, db
-from app.helpers import page_title, flash_no_permission, admin_required, urlfriendly
+from app.helpers import page_title, flash_no_permission, admin_required
 from app.map import bp
 from app.map.forms import MapNodeTypeCreateForm, MapNodeTypeEditForm, MapSettingsForm, MapNodeForm, MapForm
 from app.map.helpers import map_admin_required, map_node_filename, gen_node_type_choices, get_visible_nodes, map_changed, gen_submap_choices

--- a/app/map/routes.py
+++ b/app/map/routes.py
@@ -36,7 +36,7 @@ def index():
         flash("This map is not visible.", "danger")
         return redirect(url_for("index"))
 
-    return redirect(url_for('map.view', id=indexmap.id, name=urlfriendly(indexmap.name)))
+    return redirect(indexmap.view_url())
 
 @bp.route("/<int:id>/<string:name>")
 @bp.route("/<int:id>")
@@ -91,7 +91,7 @@ def create():
         db.session.commit()
 
         flash("Map created.", "success")
-        return redirect(url_for("map.view", id=new_map.id, name=urlfriendly(new_map.name)))
+        return redirect(new_map.view_url())
 
     return render_template("map/create.html", form=form, title=page_title("Add Map"))
 
@@ -116,7 +116,7 @@ def map_settings(id, name=None):
 
         db.session.commit()
         flash("Map settings have been changed.", "success")
-        return redirect(url_for("map.view", id=map_.id, name=urlfriendly(map_.name)))
+        return redirect(map_.view_url())
     else:
         form.name.data = map_.name
         form.no_wrap.data = map_.no_wrap

--- a/app/media/routes.py
+++ b/app/media/routes.py
@@ -74,7 +74,7 @@ def upload():
         db.session.commit()
 
         flash("Upload successful.", "success")
-        return redirect(url_for("media.view", id=new_media.id, name=urlfriendly(new_media.name)))
+        return redirect(new_media.view_url())
     elif request.method == "GET":
         if current_user.is_media_admin() and settings.default_visible:
             form.is_visible.data = True
@@ -132,7 +132,7 @@ def edit(id, name=None):
 
         flash("File was edited.", "success")
 
-        return redirect(url_for("media.view", id=id, name=urlfriendly(item.name)))
+        return redirect(item.view_url())
     elif request.method == "GET":
         form.name.data = item.name
         form.category.data = item.category_id

--- a/app/media/routes.py
+++ b/app/media/routes.py
@@ -1,5 +1,5 @@
 from app import app, db
-from app.helpers import page_title, flash_no_permission, urlfriendly
+from app.helpers import page_title, flash_no_permission
 from app.models import MediaSetting, MediaItem, MediaCategory, User, Role
 from app.media import bp
 from app.media.forms import SettingsForm, MediaItemCreateForm, MediaItemEditForm, CategoryForm

--- a/app/models.py
+++ b/app/models.py
@@ -805,7 +805,7 @@ class MediaSetting(db.Model, SimpleAuditMixin):
     id = db.Column(db.Integer, primary_key=True)
     default_visible = db.Column(db.Boolean)
 
-class MediaCategory(db.Model, SimpleAuditMixin):
+class MediaCategory(db.Model, SimpleAuditMixin, LinkGenerator):
     __tablename__ = "media_categories"
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(100))
@@ -818,7 +818,19 @@ class MediaCategory(db.Model, SimpleAuditMixin):
 
         return dic
 
-class MediaItem(db.Model, SimpleAuditMixin):
+    #####
+    # LinkGenerator functions
+    #####
+    def view_text(self):
+        return self.name
+
+    def view_url(self):
+        return url_for('media.list_by_cat', c_id=self.id, c_name=urlfriendly(self.name))
+
+    def edit_url(self):
+        return url_for('media.category_edit', id=self.id, name=urlfriendly(self.name))
+
+class MediaItem(db.Model, SimpleAuditMixin, LinkGenerator):
     __tablename__ = "media"
     id = db.Column(db.Integer, primary_key=True)
     is_visible = db.Column(db.Boolean)
@@ -843,6 +855,27 @@ class MediaItem(db.Model, SimpleAuditMixin):
         }
 
         return dic
+
+    #####
+    # LinkGenerator functions
+    #####
+    def view_text(self):
+        return self.name
+
+    def view_url(self):
+        return url_for('media.view', id=self.id, name=urlfriendly(self.name))
+
+    def edit_url(self):
+        return url_for('media.edit', id=self.id, name=urlfriendly(self.name))
+
+    def delete_url(self):
+        return url_for('media.delete', id=self.id, name=urlfriendly(self.name))
+
+    def serve_url(self):
+        return url_for('media.serve_file', filename=self.filename)
+
+    def serve_link(self):
+        return self.link(self.serve_url(), self.filename)
 
 class Journal(db.Model, SimpleAuditMixin):
     __tablename__ = "journal"

--- a/app/models.py
+++ b/app/models.py
@@ -399,12 +399,27 @@ class Character(db.Model, SimpleAuditMixin, LinkGenerator):
     def delete_url(self):
         return url_for('character.delete', id=self.id, name=urlfriendly(self.name))
 
-class Party(db.Model, SimpleAuditMixin):
+class Party(db.Model, SimpleAuditMixin, LinkGenerator):
     __tablename__ = "parties"
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(100))
     description = db.Column(db.Text)
     dm_notes = db.Column(db.Text)
+
+    #####
+    # LinkGenerator functions
+    #####
+    def view_text(self):
+        return self.name
+
+    def view_url(self):
+        return url_for('party.view', id=self.id, name=urlfriendly(self.name))
+
+    def edit_url(self):
+        return url_for('party.edit', id=self.id, name=urlfriendly(self.name))
+
+    def delete_url(self):
+        return url_for('party.delete', id=self.id, name=urlfriendly(self.name))
 
 class Session(db.Model, SimpleAuditMixin):
     __tablename__ = "sessions"

--- a/app/models.py
+++ b/app/models.py
@@ -682,13 +682,25 @@ class EventSetting(db.Model, SimpleAuditMixin):
     default_epoch = db.Column(db.Integer, db.ForeignKey("epochs.id"))
     default_year = db.Column(db.Integer)
 
-class EventCategory(db.Model, SimpleAuditMixin):
+class EventCategory(db.Model, SimpleAuditMixin, LinkGenerator):
     __tablename__ = "event_categories"
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(100))
     color = db.Column(db.String(10))
 
-class Event(db.Model, SimpleAuditMixin):
+    #####
+    # LinkGenerator functions
+    #####
+    def view_text(self):
+        return Markup('<span style="color:{};">█</span> {}'.format(self.color, self.name))
+
+    def view_url(self):
+        return url_for('event.list_category', c_id=self.id, c_name=urlfriendly(self.name))
+
+    def edit_url(self):
+        return url_for('event.category_edit', id=self.id, name=urlfriendly(self.name))
+
+class Event(db.Model, SimpleAuditMixin, LinkGenerator):
     __tablename__ = "events"
     id = db.Column(db.Integer, primary_key=True)
     is_visible = db.Column(db.Boolean)
@@ -772,6 +784,21 @@ class Event(db.Model, SimpleAuditMixin):
             return wd[(self.timestamp % len(wd)) - 1].name
         else:
             return wd[(timestamp % len(wd)) -1].name
+
+    #####
+    # LinkGenerator functions
+    #####
+    def view_text(self):
+        return self.name
+
+    def view_url(self):
+        return url_for('event.view', id=self.id, name=urlfriendly(self.name))
+
+    def edit_url(self):
+        return url_for('event.edit', id=self.id, name=urlfriendly(self.name))
+
+    def delete_url(self):
+        return url_for('event.delete', id=self.id, name=urlfriendly(self.name))
 
 class MediaSetting(db.Model, SimpleAuditMixin):
     __tablename__ = "media_settings"

--- a/app/models.py
+++ b/app/models.py
@@ -957,7 +957,7 @@ class MediaItem(db.Model, SimpleAuditMixin, LinkGenerator):
     def serve_link(self):
         return self.link(self.serve_url(), self.filename)
 
-class Journal(db.Model, SimpleAuditMixin):
+class Journal(db.Model, SimpleAuditMixin, LinkGenerator):
     __tablename__ = "journal"
 
     id = db.Column(db.Integer, primary_key=True)
@@ -970,6 +970,20 @@ class Journal(db.Model, SimpleAuditMixin):
 
     session_id = db.Column(db.Integer, db.ForeignKey('sessions.id'))
     session = db.relationship("Session", backref="journals", foreign_keys=[session_id])
+
+    # LinkGenerator functions
+    #####
+    def view_text(self):
+        return self.title
+
+    def view_url(self):
+        return url_for('character.journal_view', c_id=self.character.id, c_name=urlfriendly(self.character.name), j_id=self.id, j_name=urlfriendly(self.title))
+
+    def edit_url(self):
+        return url_for('character.journal_edit', c_id=self.character.id, c_name=urlfriendly(self.character.name), j_id=self.id, j_name=urlfriendly(self.title))
+
+    def delete_url(self):
+        return url_for('character.journal_delete', c_id=self.character.id, c_name=urlfriendly(self.character.name), j_id=self.id, j_name=urlfriendly(self.title))
 
 class Campaign(db.Model, SimpleAuditMixin, LinkGenerator):
     __tablename__ = "campaigns"

--- a/app/models.py
+++ b/app/models.py
@@ -65,10 +65,10 @@ class SimpleAuditMixin(object):
             out += "<li>Created"
 
             if self.created_by:
-                out += ' by <a href="%s">%s</a>' % (url_for('user.profile', username=self.created_by.username), self.created_by.username)
+                out += ' by {}'.format(self.created_by.view_link())
 
             if self.created:
-                out += " on %s" % app.extensions["moment"](self.created).format(current_user.dateformat)
+                out += " on {}".format(app.extensions["moment"](self.created).format(current_user.dateformat))
 
             out += "</li>"
 
@@ -77,10 +77,10 @@ class SimpleAuditMixin(object):
             out += "<li>Edited"
 
             if self.edited_by:
-                out += ' by <a href="%s">%s</a>' % (url_for('user.profile', username=self.edited_by.username), self.edited_by.username)
+                out += ' by {}'.format(self.edited_by.view_link())
 
             if self.edited:
-                out += " on %s" % app.extensions["moment"](self.edited).format(current_user.dateformat)
+                out += " on {}".format(app.extensions["moment"](self.edited).format(current_user.dateformat))
 
             out += "</li>"
 
@@ -172,7 +172,7 @@ class LinkGenerator(object):
         raise NotImplementedError
 
 
-class User(UserMixin, db.Model):
+class User(UserMixin, db.Model, LinkGenerator):
     __tablename__ = "users"
     id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(64), index=True, unique=True)
@@ -261,6 +261,18 @@ class User(UserMixin, db.Model):
 
     def __repr__(self):
         return '<User {}>'.format(self.username)
+
+    #####
+    # LinkGenerator functions
+    #####
+    def view_text(self):
+        return self.username
+
+    def view_url(self):
+        return url_for('user.profile', username=self.username)
+
+    def edit_url(self):
+        return url_for('user.edit', username=self.username)
 
 class Role(db.Model):
     __tablename__ = "roles"

--- a/app/models.py
+++ b/app/models.py
@@ -1,4 +1,5 @@
 from app import app, db, login
+from app.helpers import urlfriendly
 from datetime import datetime
 from flask import url_for
 from flask_login import UserMixin
@@ -87,6 +88,84 @@ class SimpleAuditMixin(object):
             return ""
 
         return Markup(Template(out).render(context))
+
+class LinkGenerator(object):
+    def link(self, url, text, classes=None, ids=None):
+        attrs = ""
+
+        if classes != None:
+            attrs += 'class="{}"'.format(classes)
+
+        if ids != None:
+            attrs += 'id="{}"'.format(ids)
+
+        return Markup('<a href="{}" {}>{}</a>'.format(url, attrs, text))
+
+    def button(self, url, text, icon=None, classes=None, ids=None):
+        if icon != None:
+            icon = '<span class="glyphicon glyphicon-{}" aria-hidden="true"></span>'.format(icon)
+
+        text = "{}\n{}".format(icon, text)
+        link = self.link(url, text, classes, ids)
+
+        return Markup(link)
+
+    def view_link(self, text=None, classes=None, ids=None):
+        if text == None:
+            text = self.view_text()
+
+        return self.link(self.view_url(), text, classes, ids)
+
+    def edit_link(self, text="Edit", css_classes=None, css_ids=None):
+        if text == None:
+            text = self.edit_text()
+
+        return self.link(self.edit_url(), text, classes, ids)
+
+    def delete_link(self, text="Delete", css_classes=None, css_ids=None):
+        if text == None:
+            text = self.delete_text()
+
+        return self.link(self.delete_url(), text, classes, ids)
+
+    def view_button(self, text="View", icon="eye-open", classes="btn btn-default", ids=None):
+        return self.button(self.view_url(), text, icon, classes, ids)
+
+    def edit_button(self, text="Edit", icon="pencil", classes="btn btn-default", ids=None):
+        return self.button(self.edit_url(), text, icon, classes, ids)
+
+    def delete_button(self, text="Delete", icon="remove-circle", classes="btn btn-danger", ids="delete-link"):
+        return self.button(self.delete_url(), text, icon, classes, ids)
+
+    def view_button_nav(self, text="View", icon="eye-open", classes=None, ids=None):
+        return self.button(self.view_url(), text, icon, classes, ids)
+
+    def edit_button_nav(self, text="Edit", icon="pencil", classes=None, ids=None):
+        return self.button(self.edit_url(), text, icon, classes, ids)
+
+    def delete_button_nav(self, text="Delete", icon="remove-circle", classes="btn btn-danger", ids="delete-link"):
+        return self.button(self.delete_url(), text, icon, classes, ids)
+
+    def view_text(self):
+        return "View"
+
+    def edit_text(self):
+        return "Edit"
+
+    def delete_text(self):
+        return "Delete"
+
+    # needs to be overridden by base class
+    def view_url(self):
+        raise NotImplementedError
+
+    # needs to be overridden by base class
+    def edit_url(self):
+        raise NotImplementedError
+
+    # needs to be overridden by base class
+    def delete_url(self):
+        raise NotImplementedError
 
 
 class User(UserMixin, db.Model):

--- a/app/models.py
+++ b/app/models.py
@@ -369,7 +369,7 @@ class MapNode(db.Model, SimpleAuditMixin):
 
         return dic
 
-class Character(db.Model, SimpleAuditMixin):
+class Character(db.Model, SimpleAuditMixin, LinkGenerator):
     __tablename__ = "characters"
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey('users.id'))
@@ -383,6 +383,18 @@ class Character(db.Model, SimpleAuditMixin):
     description = db.Column(db.Text)
     dm_notes = db.Column(db.Text)
     private_notes = db.Column(db.Text)
+
+    def view_text(self):
+        return self.name
+
+    def view_url(self):
+        return url_for('character.view', id=self.id, name=urlfriendly(self.name))
+
+    def edit_url(self):
+        return url_for('character.edit', id=self.id, name=urlfriendly(self.name))
+
+    def delete_url(self):
+        return url_for('character.delete', id=self.id, name=urlfriendly(self.name))
 
 class Party(db.Model, SimpleAuditMixin):
     __tablename__ = "parties"

--- a/app/models.py
+++ b/app/models.py
@@ -384,6 +384,9 @@ class Character(db.Model, SimpleAuditMixin, LinkGenerator):
     dm_notes = db.Column(db.Text)
     private_notes = db.Column(db.Text)
 
+    #####
+    # LinkGenerator functions
+    #####
     def view_text(self):
         return self.name
 
@@ -441,7 +444,7 @@ class CalendarSetting(db.Model, SimpleAuditMixin):
     id = db.Column(db.Integer, primary_key=True)
     finalized = db.Column(db.Boolean, default=False)
 
-class Epoch(db.Model, SimpleAuditMixin):
+class Epoch(db.Model, SimpleAuditMixin, LinkGenerator):
     __tablename__ = "epochs"
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(100))
@@ -469,7 +472,16 @@ class Epoch(db.Model, SimpleAuditMixin):
     def __repr__(self):
         return str(self.to_dict())
 
-class Month(db.Model, SimpleAuditMixin):
+    #####
+    # LinkGenerator functions
+    #####
+    def edit_url(self):
+        return url_for('calendar.epoch_edit', id=self.id, name=urlfriendly(self.name))
+
+    def delete_url(self):
+        return url_for('calendar.epoch_delete', id=self.id, name=urlfriendly(self.name))
+
+class Month(db.Model, SimpleAuditMixin, LinkGenerator):
     __tablename__ = "months"
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(100))
@@ -495,7 +507,16 @@ class Month(db.Model, SimpleAuditMixin):
     def __repr__(self):
         return str(self.to_dict())
 
-class Day(db.Model, SimpleAuditMixin):
+    #####
+    # LinkGenerator functions
+    #####
+    def edit_url(self):
+        return url_for('calendar.month_edit', id=self.id, name=urlfriendly(self.name))
+
+    def delete_url(self):
+        return url_for('calendar.month_delete', id=self.id, name=urlfriendly(self.name))
+
+class Day(db.Model, SimpleAuditMixin, LinkGenerator):
     __tablename__ = "days"
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(100))
@@ -515,7 +536,16 @@ class Day(db.Model, SimpleAuditMixin):
     def __repr__(self):
         return str(self.to_dict())
 
-class Moon(db.Model, SimpleAuditMixin):
+    #####
+    # LinkGenerator functions
+    #####
+    def edit_url(self):
+        return url_for('calendar.day_edit', id=self.id, name=urlfriendly(self.name))
+
+    def delete_url(self):
+        return url_for('calendar.day_delete', id=self.id, name=urlfriendly(self.name))
+
+class Moon(db.Model, SimpleAuditMixin, LinkGenerator):
     __tablename__ = "moons"
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(100))
@@ -634,6 +664,15 @@ class Moon(db.Model, SimpleAuditMixin):
             out += self.print_phase(x + 1, moon_size, print_name, print_phase) + "\n"
 
         return out
+
+    #####
+    # LinkGenerator functions
+    #####
+    def edit_url(self):
+        return url_for('calendar.moon_edit', id=self.id, name=urlfriendly(self.name))
+
+    def delete_url(self):
+        return url_for('calendar.moon_delete', id=self.id, name=urlfriendly(self.name))
 
 class EventSetting(db.Model, SimpleAuditMixin):
     __tablename__ = "event_settings"

--- a/app/models.py
+++ b/app/models.py
@@ -101,11 +101,15 @@ class LinkGenerator(object):
 
         return Markup('<a href="{}" {}>{}</a>'.format(url, attrs, text))
 
-    def button(self, url, text, icon=None, classes=None, ids=None):
+    def button(self, url, text, icon=None, classes=None, ids=None, swap=False):
         if icon != None:
             icon = '<span class="glyphicon glyphicon-{}" aria-hidden="true"></span>'.format(icon)
 
-        text = "{}\n{}".format(icon, text)
+        if swap == False:
+            text = "{}\n{}".format(icon, text)
+        else:
+            text = "{}\n{}".format(text, icon)
+
         link = self.link(url, text, classes, ids)
 
         return Markup(link)
@@ -128,23 +132,23 @@ class LinkGenerator(object):
 
         return self.link(self.delete_url(), text, classes, ids)
 
-    def view_button(self, text="View", icon="eye-open", classes="btn btn-default", ids=None):
-        return self.button(self.view_url(), text, icon, classes, ids)
+    def view_button(self, text="View", icon="eye-open", classes="btn btn-default", ids=None, swap=False):
+        return self.button(self.view_url(), text, icon, classes, ids, swap)
 
-    def edit_button(self, text="Edit", icon="pencil", classes="btn btn-default", ids=None):
-        return self.button(self.edit_url(), text, icon, classes, ids)
+    def edit_button(self, text="Edit", icon="pencil", classes="btn btn-default", ids=None, swap=False):
+        return self.button(self.edit_url(), text, icon, classes, ids, swap)
 
-    def delete_button(self, text="Delete", icon="remove-circle", classes="btn btn-danger", ids="delete-link"):
-        return self.button(self.delete_url(), text, icon, classes, ids)
+    def delete_button(self, text="Delete", icon="remove-circle", classes="btn btn-danger", ids="delete-link", swap=False):
+        return self.button(self.delete_url(), text, icon, classes, ids, swap)
 
-    def view_button_nav(self, text="View", icon="eye-open", classes=None, ids=None):
-        return self.button(self.view_url(), text, icon, classes, ids)
+    def view_button_nav(self, text="View", icon="eye-open", classes=None, ids=None, swap=False):
+        return self.button(self.view_url(), text, icon, classes, ids, swap)
 
-    def edit_button_nav(self, text="Edit", icon="pencil", classes=None, ids=None):
-        return self.button(self.edit_url(), text, icon, classes, ids)
+    def edit_button_nav(self, text="Edit", icon="pencil", classes=None, ids=None, swap=False):
+        return self.button(self.edit_url(), text, icon, classes, ids, swap)
 
-    def delete_button_nav(self, text="Delete", icon="remove-circle", classes="btn btn-danger", ids="delete-link"):
-        return self.button(self.delete_url(), text, icon, classes, ids)
+    def delete_button_nav(self, text="Delete", icon="remove-circle", classes="btn btn-danger", ids="delete-link", swap=False):
+        return self.button(self.delete_url(), text, icon, classes, ids, swap)
 
     def view_text(self):
         return "View"
@@ -421,7 +425,7 @@ class Party(db.Model, SimpleAuditMixin, LinkGenerator):
     def delete_url(self):
         return url_for('party.delete', id=self.id, name=urlfriendly(self.name))
 
-class Session(db.Model, SimpleAuditMixin):
+class Session(db.Model, SimpleAuditMixin, LinkGenerator):
     __tablename__ = "sessions"
     id = db.Column(db.Integer, primary_key=True)
     title = db.Column(db.String(100))
@@ -434,6 +438,21 @@ class Session(db.Model, SimpleAuditMixin):
 
     def get_session_number(self):
         return Session.query.filter(and_(Session.campaign_id == self.campaign_id, Session.date < self.date)).count() + 1
+
+    #####
+    # LinkGenerator functions
+    #####
+    def view_text(self):
+        return self.title
+
+    def view_url(self):
+        return url_for('session.view', id=self.id, name=urlfriendly(self.title))
+
+    def edit_url(self):
+        return url_for('session.edit', id=self.id, name=urlfriendly(self.title))
+
+    def delete_url(self):
+        return url_for('session.delete', id=self.id, name=urlfriendly(self.title))
 
 class WikiSetting(db.Model, SimpleAuditMixin):
     __tablename__ = "wiki_settings"

--- a/app/models.py
+++ b/app/models.py
@@ -490,7 +490,7 @@ class WikiSetting(db.Model, SimpleAuditMixin):
     id = db.Column(db.Integer, primary_key=True)
     default_visible = db.Column(db.Boolean, default=False)
 
-class WikiEntry(db.Model, SimpleAuditMixin):
+class WikiEntry(db.Model, SimpleAuditMixin, LinkGenerator):
     __tablename__ = "wiki_entries"
     id = db.Column(db.Integer, primary_key=True)
 
@@ -503,6 +503,21 @@ class WikiEntry(db.Model, SimpleAuditMixin):
 
     def split_tags(self):
         return self.tags.split(" ")
+
+    #####
+    # LinkGenerator functions
+    #####
+    def view_text(self):
+        return self.title
+
+    def view_url(self):
+        return url_for('wiki.view', id=self.id, name=urlfriendly(self.title))
+
+    def edit_url(self):
+        return url_for('wiki.edit', id=self.id, name=urlfriendly(self.title))
+
+    def delete_url(self):
+        return url_for('wiki.delete', id=self.id, name=urlfriendly(self.title))
 
 class CalendarSetting(db.Model, SimpleAuditMixin):
     __tablename__ = "calendar_settings"

--- a/app/models.py
+++ b/app/models.py
@@ -831,7 +831,7 @@ class Journal(db.Model, SimpleAuditMixin):
     session_id = db.Column(db.Integer, db.ForeignKey('sessions.id'))
     session = db.relationship("Session", backref="journals", foreign_keys=[session_id])
 
-class Campaign(db.Model, SimpleAuditMixin):
+class Campaign(db.Model, SimpleAuditMixin, LinkGenerator):
     __tablename__ = "campaigns"
 
     id = db.Column(db.Integer, primary_key=True)
@@ -844,6 +844,18 @@ class Campaign(db.Model, SimpleAuditMixin):
     dm_notes = db.Column(db.Text)
 
     default_participants = db.relationship("Character", secondary=campaign_character_assoc, backref="default_participants")
+
+    #####
+    # LinkGenerator functions
+    #####
+    def view_text(self):
+        return Markup('<span style="color:{};">█</span> {}'.format(self.color, self.name))
+
+    def view_url(self):
+        return url_for('campaign.view', id=self.id, name=urlfriendly(self.name))
+
+    def edit_url(self):
+        return url_for('campaign.edit', id=self.id, name=urlfriendly(self.name))
 
 @login.user_loader
 def load_user(id):

--- a/app/models.py
+++ b/app/models.py
@@ -296,7 +296,7 @@ class MapSetting(db.Model, SimpleAuditMixin):
     check_interval = db.Column(db.Integer, default=30)
     default_map = db.Column(db.Integer, db.ForeignKey("maps.id"), default=0)
 
-class Map(db.Model, SimpleAuditMixin):
+class Map(db.Model, SimpleAuditMixin, LinkGenerator):
     __tablename__ = "maps"
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(100))
@@ -316,6 +316,25 @@ class Map(db.Model, SimpleAuditMixin):
         }
 
         return dic
+
+    #####
+    # LinkGenerator functions
+    #####
+    def view_text(self):
+        return self.name
+
+    def view_url(self):
+        return url_for('map.view', id=self.id, name=urlfriendly(self.name))
+
+    def edit_url(self):
+        return url_for('map.edit', id=self.id, name=urlfriendly(self.name))
+
+    def settings_url(self):
+        return url_for("map.map_settings", id=self.id, name=urlfriendly(self.name))
+
+    def settings_button(self, ids=None):
+        url = self.settings_url()
+        return self.button(url=url, text="Settings", icon="cog", ids=None, classes="btn btn-default")
 
 class MapNodeType(db.Model, SimpleAuditMixin):
     __tablename__ = "map_node_types"

--- a/app/party/routes.py
+++ b/app/party/routes.py
@@ -26,7 +26,7 @@ def create():
         db.session.commit()
 
         flash("Party was created.", "success")
-        return redirect(url_for("party.view", id=new_party.id, name=urlfriendly(new_party.name)))
+        return redirect(new_party.view_url())
 
     return render_template("party/create.html", form=form, title=page_title("Add Party"))
 
@@ -57,7 +57,7 @@ def edit(id, name=None):
 
         db.session.commit()
         flash("Party was changed.", "success")
-        return redirect(url_for("party.view", id=id, name=urlfriendly(party.name)))
+        return redirect(party.view_url())
 
     elif request.method == "GET":
         form.name.data = party.name

--- a/app/party/routes.py
+++ b/app/party/routes.py
@@ -1,5 +1,5 @@
 from app import db
-from app.helpers import page_title, admin_required, admin_or_party_required, urlfriendly
+from app.helpers import page_title, admin_required, admin_or_party_required
 from app.models import Character, Party
 from app.party import bp
 from app.party.forms import PartyForm

--- a/app/session/routes.py
+++ b/app/session/routes.py
@@ -94,7 +94,7 @@ def create_with_campaign(id):
         db.session.commit()
 
         flash("Session was created.", "success")
-        return redirect(url_for("session.view", id=new_session.id, name=urlfriendly(new_session.title)))
+        return redirect(new_session.view_url())
     elif request.method == "GET":
         participants = []
 
@@ -144,7 +144,7 @@ def edit(id, name=None):
 
         db.session.commit()
         flash("Session was changed.", "success")
-        return redirect(url_for("session.view", id=id, name=urlfriendly(session.title)))
+        return redirect(session.view_url())
     elif request.method == "GET":
         form.title.data = session.title
         form.summary.data = session.summary

--- a/app/session/routes.py
+++ b/app/session/routes.py
@@ -1,5 +1,5 @@
 from app import db
-from app.helpers import page_title, admin_required, admin_dm_or_session_required, admin_or_dm_required, urlfriendly, count_rows
+from app.helpers import page_title, admin_required, admin_dm_or_session_required, admin_or_dm_required, count_rows
 from app.models import Character, Session, Campaign
 from app.session import bp
 from app.session.forms import SessionForm, CampaignSelectForm

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -154,7 +154,7 @@ $(document).ready(function() {
                     <span class="glyphicon glyphicon-user"></span> {{ current_user.username }} <span class="caret"></span>
                     </a>
                     <ul class="dropdown-menu">
-                        <li><a href="{{ url_for('user.profile', username=current_user.username) }}">Profile</a></li>
+                        <li>{{ current_user.view_link() }}</li>
                         <li><a href="{{ url_for('user.settings') }}">Settings</a></li>
                         <li><a href="{{ url_for('logout') }}">Logout</a></li>
                     </ul>

--- a/app/templates/calendar/form.html
+++ b/app/templates/calendar/form.html
@@ -12,7 +12,7 @@
 {{ include_js(['simplemde', 'moment']) }}
 
 <script>
-SimpleMDE(generateSMDEConfig("description"));
+SimpleMDE("description");
 </script>
 {% endblock %}
 

--- a/app/templates/calendar/index.html
+++ b/app/templates/calendar/index.html
@@ -73,7 +73,9 @@ The calendar has not been finalized by the admin yet.
 
 <ul class="list-unstyled">
 {% for cat in categories %}
-<li style="border-left:7px solid {{ cat.color }};padding-left:10px;"><a href="{{ url_for('event.list_category', c_id=cat.id, c_name=cat.name|urlfriendly) }}">{{ cat.name }} ({{ cat.events|length }})</a></li>
+<li>
+    {{ cat.view_link(text="{} ({})".format(cat.view_text(), cat.events|length)) }}
+</li>
 {% endfor %}
 </ul>
 

--- a/app/templates/calendar/settings.html
+++ b/app/templates/calendar/settings.html
@@ -103,10 +103,7 @@ For a valid calendar, only the bottom-most epoch can have a duration of 0.
                 {% endif %}
             </td>
             <td>
-                <a href="{{ url_for('calendar.epoch_edit', id=epoch.id, name=epoch.name|urlfriendly) }}" class="btn btn-default">
-                    <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-                    Edit
-                </a>
+                {{ epoch.edit_button() }}
 
                 {% if settings.finalized == False %}
                 <a href="{{ url_for('calendar.epoch_up', id=epoch.id, name=epoch.name|urlfriendly) }}" class="btn btn-default">
@@ -117,10 +114,7 @@ For a valid calendar, only the bottom-most epoch can have a duration of 0.
                     <span class="glyphicon glyphicon-arrow-down" aria-hidden="true"></span>
                 </a>
 
-                <a href="{{ url_for('calendar.epoch_delete', id=epoch.id, name=epoch.name|urlfriendly) }}" class="btn btn-danger">
-                    <span class="glyphicon glyphicon-remove-circle"></span>
-                    Delete
-                </a>
+                {{ epoch.delete_button() }}
                 {% endif %}
             </td>
         </tr>
@@ -178,10 +172,7 @@ For a valid calendar, at least one month must be defined and each month must hav
                 {{ month.days }} days
             </td>
             <td>
-                <a href="{{ url_for('calendar.month_edit', id=month.id, name=month.name|urlfriendly) }}" class="btn btn-default">
-                    <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-                    Edit
-                </a>
+                {{ month.edit_button() }}
 
                 {% if settings.finalized == False %}
                 <a href="{{ url_for('calendar.month_up', id=month.id, name=month.name|urlfriendly) }}" class="btn btn-default">
@@ -192,10 +183,7 @@ For a valid calendar, at least one month must be defined and each month must hav
                     <span class="glyphicon glyphicon-arrow-down" aria-hidden="true"></span>
                 </a>
 
-                <a href="{{ url_for('calendar.month_delete', id=month.id, name=month.name|urlfriendly) }}" class="btn btn-danger">
-                    <span class="glyphicon glyphicon-remove-circle"></span>
-                    Delete
-                </a>
+                {{ month.delete_button() }}
                 {% endif %}
             </td>
         </tr>
@@ -250,10 +238,7 @@ For a valid calendar, at least one day must be defined.
                 {% endif %}
             </td>
             <td>
-                <a href="{{ url_for('calendar.day_edit', id=day.id, name=day.name|urlfriendly) }}" class="btn btn-default">
-                    <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-                    Edit
-                </a>
+                {{ day.edit_button() }}
 
                 {% if settings.finalized == False %}
                 <a href="{{ url_for('calendar.day_up', id=day.id, name=day.name|urlfriendly) }}" class="btn btn-default">
@@ -264,10 +249,7 @@ For a valid calendar, at least one day must be defined.
                     <span class="glyphicon glyphicon-arrow-down" aria-hidden="true"></span>
                 </a>
 
-                <a href="{{ url_for('calendar.day_delete', id=day.id, name=day.name|urlfriendly) }}" class="btn btn-danger">
-                    <span class="glyphicon glyphicon-remove-circle"></span>
-                    Delete
-                </a>
+                {{ day.delete_button() }}
                 {% endif %}
             </td>
         </tr>
@@ -333,16 +315,10 @@ The phase can be offset by the shift field, so not every moon starts as a new mo
                 </div>
             </td>
             <td>
-                <a href="{{ url_for('calendar.moon_edit', id=moon.id, name=moon.name|urlfriendly) }}" class="btn btn-default">
-                    <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-                    Edit
-                </a>
+                {{ moon.edit_button() }}
 
                 {% if settings.finalized == False %}
-                <a href="{{ url_for('calendar.moon_delete', id=moon.id, name=moon.name|urlfriendly) }}" class="btn btn-danger">
-                    <span class="glyphicon glyphicon-remove-circle"></span>
-                    Delete
-                </a>
+                {{ moon.delete_button() }}
                 {% endif %}
             </td>
         </tr>

--- a/app/templates/campaign/edit.html
+++ b/app/templates/campaign/edit.html
@@ -23,7 +23,7 @@ makeMultiSelect("default_participants", "Available", "Participants", "partymembe
 {% endblock %}
 
 {% block app_content %}
-    <h1>Create New Campaign</h1>
+    <h1>Edit Campaign</h1>
 
     {{ wtf.quick_form(form) }}
 {% endblock %}

--- a/app/templates/campaign/list.html
+++ b/app/templates/campaign/list.html
@@ -57,15 +57,10 @@ makeDatatable("campaigns-table");
                 {# <td>{{ moment(session.date).format(current_user.dateformat) }} ({{ moment(session.date).fromNow() }})</td>#}
                 <td>{{ campaign.sessions|length }}</td>
                 <td>
-                    <a href="{{ url_for('campaign.view', id=campaign.id, name=campaign.name|urlfriendly) }}" class="btn btn-default">
-                        <span class="glyphicon glyphicon-eye-open" aria-hidden="true"></span>
-                        View
-                    </a>
+                    {{ campaign.view_button() }}
                     {% if current_user.is_dm_of(campaign) or current_user.has_admin_role() %}
-                    <a href="{{ url_for('campaign.edit', id=campaign.id, name=campaign.name|urlfriendly) }}" class="btn btn-default">
-                        <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-                        Edit
-                    </a>
+                    {{ campaign.edit_button() }}
+
                     <a href="{{ url_for('session.create_with_campaign', id=campaign.id) }}" class="btn btn-default">
                         <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
                         Add Session

--- a/app/templates/campaign/list.html
+++ b/app/templates/campaign/list.html
@@ -53,7 +53,7 @@ makeDatatable("campaigns-table");
         {% for campaign in campaigns %}
             <tr style="border-left:7px solid {{ campaign.color }}">
                 <td>{{ campaign.name }}</td>
-                <td><a href="{{ url_for('user.profile', username=campaign.dm.username) }}">{{ campaign.dm.username }}</a></td>
+                <td>{{ campaign.dm.view_link() }}</td>
                 {# <td>{{ moment(session.date).format(current_user.dateformat) }} ({{ moment(session.date).fromNow() }})</td>#}
                 <td>{{ campaign.sessions|length }}</td>
                 <td>

--- a/app/templates/campaign/view.html
+++ b/app/templates/campaign/view.html
@@ -28,10 +28,7 @@ makeDatatable("sessions-table");
         </a>
     </li>
     <li>
-        <a href="{{ url_for('campaign.edit', id=campaign.id, name=campaign.name|urlfriendly) }}">
-            <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-            Edit Campaign
-        </a>
+        {{ campaign.edit_button_nav(text="Edit Campaign") }}
     </li>
 </ul>
 {% endif %}

--- a/app/templates/campaign/view.html
+++ b/app/templates/campaign/view.html
@@ -77,8 +77,7 @@ makeDatatable("sessions-table");
 {% if campaign.default_participants %}
 <ul class="list-unstyled">
     {% for member in campaign.default_participants %}
-    <li><a href="{{ url_for('character.view', id=member.id, name=member.name|urlfriendly) }}">{{ member.name }}</a>
-    </li>
+    <li>{{ member.view_link() }}</li>
     {% endfor %}
 </ul>
 {% else %}
@@ -115,9 +114,9 @@ makeDatatable("sessions-table");
                         {% endif %}
 
                         {% if p.player.id == current_user.id %}
-                <a href="{{ url_for('character.view', id=p.id, name=p.name|urlfriendly) }}"><b>{{ p.name }}</b></a>
+                            {{ p.view_link(classes="own-char") }}
                         {% else %}
-                <a href="{{ url_for('character.view', id=p.id, name=p.name|urlfriendly) }}">{{ p.name }}</a>
+                            {{ p.view_link() }}
                         {% endif %}
                     {% endfor %}
                 {% endif %}

--- a/app/templates/campaign/view.html
+++ b/app/templates/campaign/view.html
@@ -36,7 +36,7 @@ makeDatatable("sessions-table");
 <h2>Info</h2>
 <dl class="dl-horizontal">
     <dt>DM</dt>
-    <dd><a href="{{ url_for('user.profile', username=campaign.dm.username) }}">{{ campaign.dm.username }}</a></dd>
+    <dd>{{ campaign.dm.view_link() }}</dd>
     <dt>Sessions</dt>
     <dd>{{ campaign.sessions|length }}</dd>
     <dt>Color</dt>

--- a/app/templates/campaign/view.html
+++ b/app/templates/campaign/view.html
@@ -119,15 +119,9 @@ makeDatatable("sessions-table");
                 {% endif %}
             </td>
             <td>
-                <a href="{{ url_for('session.view', id=session.id, name=session.title|urlfriendly) }}" class="btn btn-default">
-                    <span class="glyphicon glyphicon-eye-open" aria-hidden="true"></span>
-                    View
-                </a>
+                {{ session.view_button() }}
                 {% if current_user.has_char_in_session(session) or current_user.has_admin_role() %}
-                <a href="{{ url_for('session.edit', id=session.id, name=session.title|urlfriendly) }}" class="btn btn-default">
-                    <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-                    Edit
-                </a>
+                {{ session.edit_button() }}
                 {% endif %}
             </td>
         </tr>

--- a/app/templates/character/journal_list.html
+++ b/app/templates/character/journal_list.html
@@ -11,10 +11,7 @@
 
 <ul class="nav nav-tabs">
     <li>
-        <a href="{{ url_for('character.view', id=char.id, name=char.name|urlfriendly) }}">
-            <span class="glyphicon glyphicon-arrow-left" aria-hidden="true"></span>
-            Back to Char
-        </a>
+        {{ char.view_button_nav(text="Back to Char", icon="arrow-left") }}
     </li>
 
 {% if current_user == char.player %}

--- a/app/templates/character/journal_list.html
+++ b/app/templates/character/journal_list.html
@@ -41,9 +41,9 @@
     {% else %}
     <h2 class="invisible_item">{{ journal.title }}</h2>
     {% endif %}
-    <a href="{{ url_for('character.journal_view', c_id=char.id, j_id=journal.id, c_name=char.name|urlfriendly, j_name=journal.title|urlfriendly) }}">View</a>
+    {{ journal.view_link(text="View") }}
     {% if current_user == char.player or current_user.has_admin_role() %}
-    &bullet; <a href="{{ url_for('character.journal_edit', c_id=char.id, j_id=journal.id, c_name=char.name|urlfriendly, j_name=journal.title|urlfriendly) }}">Edit</a>
+    &bullet; {{ journal.edit_link() }}
     {% endif %}
 
     {% if journal.content %}

--- a/app/templates/character/journal_view.html
+++ b/app/templates/character/journal_view.html
@@ -24,16 +24,10 @@ $(document).ready(function() {
 {% if current_user == char.player or current_user.has_admin_role() %}
 <ul class="nav nav-tabs">
     <li>
-        <a href="{{ url_for('character.journal_edit', c_id=char.id, j_id=journal.id, c_name=char.name|urlfriendly, j_name=journal.title|urlfriendly) }}">
-            <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-            Edit
-        </a>
+        {{ journal.edit_button_nav() }}
     </li>
     <li class="delete-li">
-        <a href="{{ url_for('character.journal_delete', c_id=char.id, j_id=journal.id, c_name=char.name|urlfriendly, j_name=journal.title|urlfriendly) }}" class="nav-danger" id="delete-link">
-            <span class="glyphicon glyphicon-remove-circle" aria-hidden="true"></span>
-            Delete
-        </a>
+        {{ journal.delete_button_nav() }}
     </li>
 </ul>
 {% endif %}

--- a/app/templates/character/journal_view.html
+++ b/app/templates/character/journal_view.html
@@ -39,10 +39,10 @@ $(document).ready(function() {
 {% endif %}
 
 <ul class="list-unstyled">
-    <li>Written by: <a href="{{ url_for('character.view', id=char.id, name=char.name|urlfriendly) }}">{{ char.name }}</a></li>
+    <li>Written by: {{ char.view_link() }}</li>
 
     {% if journal.session %}
-    <li>Belongs to session <a href="{{ url_for('session.view', id=journal.session_id, name=journal.session.title|urlfriendly) }}">{{ journal.session.title }}</a></li>
+    <li>Belongs to Session <a href="{{ url_for('session.view', id=journal.session_id, name=journal.session.title|urlfriendly) }}">{{ journal.session.title }}</a></li>
     {% endif %}
 
     {% if current_user == char.player or current_user.has_admin_role() %}

--- a/app/templates/character/journal_view.html
+++ b/app/templates/character/journal_view.html
@@ -42,7 +42,7 @@ $(document).ready(function() {
     <li>Written by: {{ char.view_link() }}</li>
 
     {% if journal.session %}
-    <li>Belongs to Session <a href="{{ url_for('session.view', id=journal.session_id, name=journal.session.title|urlfriendly) }}">{{ journal.session.title }}</a></li>
+    <li>Belongs to Session {{ journal.session.view_link() }} of {{ journal.session.campaign.view_link() }}</li>
     {% endif %}
 
     {% if current_user == char.player or current_user.has_admin_role() %}

--- a/app/templates/character/list.html
+++ b/app/templates/character/list.html
@@ -109,20 +109,14 @@ makeDatatable("parties-table", 5);
     <tbody>
     {% for char in chars %}
         <tr>
-            <td> {{ char.name }}</td>
+            <td> {{ char.name }} </td>
             <td> {{ char.race }}</td>
             <td> {{ char.class_ }}</td>
             <td> <a href="{{ url_for('user.profile', username=char.player.username) }}">{{ char.player.username }}</a></td>
             <td>
-                <a href="{{ url_for('character.view', id=char.id, name=char.name|urlfriendly) }}" class="btn btn-default">
-                    <span class="glyphicon glyphicon-eye-open" aria-hidden="true"></span>
-                    View
-                </a>
-                {% if current_user.has_admin_role() %}
-                <a href="{{ url_for('character.edit', id=char.id, name=char.name|urlfriendly) }}" class="btn btn-default">
-                    <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-                    Edit
-                </a>
+                {{ char.view_button() }}
+                {% if current_user.has_admin_role() or char.player.id == current_user.id %}
+                {{ char.edit_button() }}
                 {% endif %}
             </td>
         </tr>

--- a/app/templates/character/list.html
+++ b/app/templates/character/list.html
@@ -106,7 +106,7 @@ makeDatatable("parties-table", 5);
             <td> {{ char.name }} </td>
             <td> {{ char.race }}</td>
             <td> {{ char.class_ }}</td>
-            <td> <a href="{{ url_for('user.profile', username=char.player.username) }}">{{ char.player.username }}</a></td>
+            <td> {{ char.player.view_link() }}</td>
             <td>
                 {{ char.view_button() }}
                 {% if current_user.has_admin_role() or char.player.id == current_user.id %}

--- a/app/templates/character/list.html
+++ b/app/templates/character/list.html
@@ -59,15 +59,9 @@ makeDatatable("parties-table", 5);
             <td> {{ party.name }}</td>
             <td> {{ party.members|length }}</td>
             <td>
-                <a href="{{ url_for('party.view', id=party.id, name=party.name|urlfriendly) }}" class="btn btn-default">
-                    <span class="glyphicon glyphicon-eye-open" aria-hidden="true"></span>
-                    View
-                </a>
+                {{ party.view_button() }}
                 {% if current_user.has_char_in_party(party) or current_user.has_admin_role() %}
-                <a href="{{ url_for('party.edit', id=party.id, name=party.name|urlfriendly) }}" class="btn btn-default">
-                    <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-                    Edit
-                </a>
+                {{ party.edit_button() }}
                 {% endif %}
             </td>
         </tr>

--- a/app/templates/character/view.html
+++ b/app/templates/character/view.html
@@ -72,7 +72,7 @@
         <dt>Class</dt>
         <dd>{{ char.class_ }}</dd>
         <dt>Player</dt>
-        <dd><a href="{{ url_for('user.profile', username=char.player.username) }}">{{ char.player.username }}</a></dd>
+        <dd>{{ char.player.view_link() }}</dd>
         {% if char.sessions %}
             <dt>Sessions</dt>
             <dd>{{ char.sessions|length }}</dd>

--- a/app/templates/character/view.html
+++ b/app/templates/character/view.html
@@ -102,15 +102,9 @@
                 <td> {{ party.name }}</td>
                 <td> {{ party.members|length }}</td>
                 <td>
-                    <a href="{{ url_for('party.view', id=party.id, name=party.name|urlfriendly) }}" class="btn btn-default">
-                        <span class="glyphicon glyphicon-eye-open" aria-hidden="true"></span>
-                        View
-                    </a>
+                    {{ party.view_button() }}
                     {% if current_user.has_char_in_party(party) or current_user.has_admin_role() %}
-                    <a href="{{ url_for('party.edit', id=party.id, name=party.name|urlfriendly) }}" class="btn btn-default">
-                        <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-                        Edit
-                    </a>
+                    {{ party.edit_button() }}
                     {% endif %}
                 </td>
             </tr>

--- a/app/templates/character/view.html
+++ b/app/templates/character/view.html
@@ -156,16 +156,10 @@
                     {% endif %}
                 </td>
                 <td>
-                    <a href="{{ url_for('character.journal_view', c_id=char.id, j_id=journal.id, c_name=char.name|urlfriendly, j_name=journal.title|urlfriendly) }}" class="btn btn-default">
-                        <span class="glyphicon glyphicon-eye-open" aria-hidden="true"></span>
-                        View
-                    </a>
+                    {{ journal.view_button() }}
 
                     {% if char.player == current_user or current_user.has_admin_role() %}
-                    <a href="{{ url_for('character.journal_edit', c_id=char.id, j_id=journal.id, c_name=char.name|urlfriendly, j_name=journal.title|urlfriendly) }}" class="btn btn-default">
-                        <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-                        Edit
-                    </a>
+                    {{ journal.edit_button() }}
                     {% endif %}
                 </td>
             </tr>

--- a/app/templates/character/view.html
+++ b/app/templates/character/view.html
@@ -54,16 +54,10 @@
         {% endif %}
     {% if char.player == current_user or current_user.has_admin_role() %}
         <li>
-            <a href="{{ url_for('character.edit', id=char.id, name=char.name|urlfriendly) }}">
-                <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-                Edit Character
-            </a>
+            {{ char.edit_button_nav(text="Edit Character") }}
         </li>
         <li class="delete-li">
-            <a href="{{ url_for('character.delete', id=char.id, name=char.name|urlfriendly) }}" class="nav-danger" id="delete-link">
-                <span class="glyphicon glyphicon-remove-circle" aria-hidden="true"></span>
-                Delete
-            </a>
+            {{ char.delete_button_nav() }}
         </li>
     {% endif %}
     </ul>

--- a/app/templates/character/view.html
+++ b/app/templates/character/view.html
@@ -152,7 +152,7 @@
                 <td>{{ journal.title }}</td>
                 <td>
                     {% if journal.session %}
-                    <a href="{{ url_for('session.view', id=journal.session_id, name=journal.session.title|urlfriendly) }}">{{ journal.session.title }}</a>
+                    {{ journal.session.view_link() }}
                     {% endif %}
                 </td>
                 <td>

--- a/app/templates/event/list.html
+++ b/app/templates/event/list.html
@@ -65,15 +65,9 @@ makeDatatable("event-table");
                     {% endif %}
                 </td>
                 <td>
-                    <a href="{{ url_for('event.view', id=event.id, name=event.name|urlfriendly) }}" class="btn btn-default">
-                        <span class="glyphicon glyphicon-eye-open" aria-hidden="true"></span>
-                        View
-                    </a>
+                    {{ event.view_button() }}
 
-                    <a href="{{ url_for('event.edit', id=event.id, name=event.name|urlfriendly) }}" class="btn btn-default">
-                        <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-                        Edit
-                    </a>
+                    {{ event.edit_button() }}
                 </td>
             </tr>
         {% endfor %}

--- a/app/templates/event/settings.html
+++ b/app/templates/event/settings.html
@@ -54,10 +54,7 @@
             </td>
             <td style="background:{{ cat.color }}">{{ cat.color }}</td>
             <td>
-                <a href="{{ url_for('event.category_edit', id=cat.id, name=cat.name|urlfriendly) }}" class="btn btn-default">
-                    <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-                    Edit
-                </a>
+                {{ cat.edit_button() }}
             </td>
         </tr>
         {% endfor %}

--- a/app/templates/event/view.html
+++ b/app/templates/event/view.html
@@ -24,24 +24,18 @@
 
     <ul class="nav nav-tabs">
         <li>
-            <a href="{{ url_for('event.edit', id=event.id, name=event.name|urlfriendly) }}">
-                <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-                Edit
-            </a>
+            {{ event.edit_button_nav() }}
         </li>
         {% if current_user.is_event_admin() %}
         <li class="delete-li">
-            <a href="{{ url_for('event.delete', id=event.id, name=event.name|urlfriendly) }}" class="nav-danger" id="delete-link">
-                <span class="glyphicon glyphicon-remove-circle" aria-hidden="true"></span>
-                Delete
-            </a>
+            {{ event.delete_button_nav() }}
         </li>
         {% endif %}
     </ul>
 
     <dl class="dl-horizontal">
         <dt>Category</dt>
-        <dd><a href="{{ url_for('event.list_category', c_id=event.category.id, c_name=event.category.name|urlfriendly) }}" style="padding-left:10px;border-left:7px solid {{ event.category.color }}">{{ event.category.name }}</a></dd>
+        <dd>{{ event.category.view_link() }}</dd>
         <dt>Date</dt>
         <dd>{{ event.start_date(False, with_link=True, with_weekday=True)|safe }}</dd>
         {% if event.duration > 1 %}

--- a/app/templates/map/index.html
+++ b/app/templates/map/index.html
@@ -61,10 +61,7 @@
       <span class="glyphicon glyphicon-list"></span>
       Ĺist
     </a>
-    <a id="btn-settings" class="btn btn-default" href="{{ url_for('map.map_settings', id=map_.id, name=map_.name|urlfriendly) }}">
-      <span class="glyphicon glyphicon-cog"></span>
-      Settings
-    </a>
+    {{ map_.settings_button(ids="btn-settings") }}
   {% endif %}
   </div>
 {% endblock %}

--- a/app/templates/map/list.html
+++ b/app/templates/map/list.html
@@ -51,14 +51,8 @@ makeDatatable("map-table");
         <tr>
             <td> {{ map.name }}</td>
             <td>
-                <a href="{{ url_for('map.view', id=map.id, name=map.name|urlfriendly) }}" class="btn btn-default">
-                    <span class="glyphicon glyphicon-eye-open" aria-hidden="true"></span>
-                    View
-                </a>
-                <a href="{{ url_for('map.map_settings', id=map.id, name=map.name|urlfriendly) }}" class="btn btn-default">
-                    <span class="glyphicon glyphicon-cog" aria-hidden="true"></span>
-                    Settings
-                </a>
+                {{ map.view_button() }}
+                {{ map.settings_button() }}
             </td>
         </tr>
     {% endfor %}

--- a/app/templates/media/index.html
+++ b/app/templates/media/index.html
@@ -60,21 +60,15 @@ makeDatatable("media-table", 25, 25);
             <tr class="invisible_item">
             {% endif %}
                 <td>{{ item.name }}</td>
-                <td><a href="{{ url_for('media.list_by_cat', c_id=item.category.id, c_name=item.category.name|urlfriendly) }}">{{ item.category.name }}</a></td>
+                <td>{{ item.category.view_link() }}</td>
                 <td>
                     {{ item.get_file_ext() }}
                 </td>
                 <td>{{ item.filename }}</td>
                 <td>
-                    <a href="{{ url_for('media.view', id=item.id, name=item.name|urlfriendly) }}" class="btn btn-default">
-                        <span class="glyphicon glyphicon-eye-open" aria-hidden="true"></span>
-                        View
-                    </a>
+                    {{ item.view_button() }}
 
-                    <a href="{{ url_for('media.edit', id=item.id, name=item.name|urlfriendly) }}" class="btn btn-default">
-                        <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-                        Edit
-                    </a>
+                   {{ item.edit_button() }}
                 </td>
             </tr>
         {% endfor %}

--- a/app/templates/media/list.html
+++ b/app/templates/media/list.html
@@ -55,15 +55,9 @@ makeDatatable("media-table", 25, 25);
                 </td>
                 <td>{{ item.filename }}</td>
                 <td>
-                    <a href="{{ url_for('media.view', id=item.id, name=item.name|urlfriendly) }}" class="btn btn-default">
-                        <span class="glyphicon glyphicon-eye-open" aria-hidden="true"></span>
-                        View
-                    </a>
+                    {{ item.view_button() }}
 
-                    <a href="{{ url_for('media.edit', id=item.id, name=item.name|urlfriendly) }}" class="btn btn-default">
-                        <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-                        Edit
-                    </a>
+                    {{ item.edit_button() }}
                 </td>
             </tr>
         {% endfor %}

--- a/app/templates/media/settings.html
+++ b/app/templates/media/settings.html
@@ -52,10 +52,7 @@
             {{ cat.name }}
             </td>
             <td>
-                <a href="{{ url_for('media.category_edit', id=cat.id, name=cat.name|urlfriendly) }}" class="btn btn-default">
-                    <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-                    Edit
-                </a>
+                {{ cat.edit_button() }}
             </td>
         </tr>
         {% endfor %}

--- a/app/templates/media/view.html
+++ b/app/templates/media/view.html
@@ -24,31 +24,25 @@ $(document).ready(function() {
 
     <ul class="nav nav-tabs">
         <li>
-            <a href="{{ url_for('media.edit', id=item.id, name=item.name|urlfriendly) }}">
-                <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-                Edit
-            </a>
+            {{ item.edit_button_nav() }}
         </li>
 
         {% if current_user.is_media_admin() %}
         <li class="delete-li">
-            <a href="{{ url_for('media.delete', id=item.id, name=item.name|urlfriendly) }}" class="nav-danger" id="delete-link">
-                <span class="glyphicon glyphicon-remove-circle" aria-hidden="true"></span>
-                Delete
-            </a>
+            {{ item.delete_button_nav() }}
         </li>
         {% endif %}
     </ul>
 
     <dl class="dl-horizontal">
         <dt>Category</dt>
-        <dd><a href="{{ url_for('media.list_by_cat', c_id=item.category.id, c_name=item.category.name|urlfriendly) }}">{{ item.category.name }}</a></dd>
+        <dd>{{ item.category.view_link() }}</dd>
         <dt>File name</dt>
         <dd>{{ item.filename }}</dd>
         <dt>File size</dt>
         <dd>{{ item.filesize|filesizeformat(True) }} ({{ item.filesize }} Byte)</dd>
         <dt>Direct link</dt>
-        <dd><a href="{{ url_for('media.serve_file', filename=item.filename) }}">{{ item.filename }}</a></dd>
+        <dd>{{ item.serve_link() }}</dd>
     </dl>
 
     {% if item.get_file_ext() in ["png", "gif", "jpg", "jpeg"] %}

--- a/app/templates/party/view.html
+++ b/app/templates/party/view.html
@@ -59,7 +59,7 @@
 <ul class="list-unstyled">
     {% for member in party.members %}
     <li>
-        <a href="{{ url_for('character.view', id=member.id, name=member.name|urlfriendly) }}">{{ member.name }}</a>
+        {{ member.view_link() }}
     </li>
     {% endfor %}
 </ul>

--- a/app/templates/party/view.html
+++ b/app/templates/party/view.html
@@ -26,17 +26,11 @@
 {% if current_user.has_char_in_party(party) or current_user.has_admin_role() %}
 <ul class="nav nav-tabs">
     <li>
-        <a href="{{ url_for('party.edit', id=party.id, name=party.name|urlfriendly) }}">
-            <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-            Edit
-        </a>
+        {{ party.edit_button_nav() }}
     </li>
     {% if current_user.has_admin_role() %}
     <li class="delete-li">
-        <a href="{{ url_for('party.delete', id=party.id, name=party.name|urlfriendly) }}" class="nav-danger" id="delete-link">
-            <span class="glyphicon glyphicon-remove-circle" aria-hidden="true"></span>
-            Delete
-        </a>
+        {{ party.delete_button_nav() }}
     </li>
 {% endif %}
 </ul>

--- a/app/templates/session/list.html
+++ b/app/templates/session/list.html
@@ -104,9 +104,9 @@ $(document).ready(function() {
                             {% endif %}
 
                             {% if p.player.id == current_user.id %}
-                    <a href="{{ url_for('character.view', id=p.id, name=p.name|urlfriendly) }}"><b>{{ p.name }}</b></a>
+                                {{ p.view_link(classes="own-char") }}
                             {% else %}
-                    <a href="{{ url_for('character.view', id=p.id, name=p.name|urlfriendly) }}">{{ p.name }}</a>
+                                {{ p.view_link() }}
                             {% endif %}
                         {% endfor %}
                     {% endif %}
@@ -162,9 +162,9 @@ $(document).ready(function() {
                             {% endif %}
 
                             {% if p.player.id == current_user.id %}
-                    <a href="{{ url_for('character.view', id=p.id) }}"><b>{{ p.name }}</b></a>
+                                {{ p.view_link(classes="own-char") }}
                             {% else %}
-                    <a href="{{ url_for('character.view', id=p.id) }}">{{ p.name }}</a>
+                                {{ p.view_link() }}
                             {% endif %}
                         {% endfor %}
                     {% endif %}

--- a/app/templates/session/list.html
+++ b/app/templates/session/list.html
@@ -112,15 +112,9 @@ $(document).ready(function() {
                     {% endif %}
                 </td>
                 <td>
-                    <a href="{{ url_for('session.view', id=session.id, name=session.title|urlfriendly) }}" class="btn btn-default">
-                        <span class="glyphicon glyphicon-eye-open" aria-hidden="true"></span>
-                        View
-                    </a>
+                    {{ session.view_button() }}
                     {% if current_user.has_char_in_session(session) or current_user.has_admin_role() %}
-                    <a href="{{ url_for('session.edit', id=session.id, name=session.title|urlfriendly) }}" class="btn btn-default">
-                        <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-                        Edit
-                    </a>
+                    {{ session.edit_button() }}
                     {% endif %}
                 </td>
             </tr>
@@ -170,15 +164,9 @@ $(document).ready(function() {
                     {% endif %}
                 </td>
                 <td>
-                    <a href="{{ url_for('session.view', id=session.id, name=session.title|urlfriendly) }}" class="btn btn-default">
-                        <span class="glyphicon glyphicon-eye-open" aria-hidden="true"></span>
-                        View
-                    </a>
+                    {{ session.view_button() }}
                     {% if current_user.has_char_in_session(session) or current_user.has_admin_role() %}
-                    <a href="{{ url_for('session.edit', id=session.id, name=session.title|urlfriendly) }}" class="btn btn-default">
-                        <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-                        Edit
-                    </a>
+                    {{ session.edit_button() }}
                     {% endif %}
                 </td>
             </tr>

--- a/app/templates/session/view.html
+++ b/app/templates/session/view.html
@@ -25,28 +25,19 @@
 <ul class="nav nav-tabs">
 {% if prev %}
     <li>
-        <a href="{{ url_for('session.view', id=prev.id, name=prev.title|urlfriendly) }}">
-            <span class="glyphicon glyphicon-arrow-left" aria-hidden="true"></span>
-            Previous session
-        </a>
+        {{ prev.view_button_nav(text="Previous Session", icon="arrow-left") }}
     </li>
 {% endif %}
 
 {% if current_user.has_char_in_session(session) or current_user.has_admin_role() or current_user.is_dm_of(session.campaign) %}
     <li>
-        <a href="{{ url_for('session.edit', id=session.id, name=session.title|urlfriendly) }}">
-            <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-            Edit session
-        </a>
+        {{ session.edit_button_nav(text="Edit Session") }}
     </li>
 {% endif %}
 
 {% if next %}
     <li>
-        <a href="{{ url_for('session.view', id=next.id, name=next.title|urlfriendly) }}">
-            Next session
-            <span class="glyphicon glyphicon-arrow-right" aria-hidden="true"></span>
-        </a>
+        {{ next.view_button_nav(text="Next Session", icon="arrow-right", swap=True) }}
     </li>
 {% elif current_user.has_admin_role() or current_user.is_dm_of(session.campaign) %}
     <li>
@@ -59,10 +50,7 @@
 
 {% if current_user.is_event_admin() %}
     <li class="delete-li">
-        <a href="{{ url_for('session.delete', id=session.id, name=session.title|urlfriendly) }}" class="nav-danger" id="delete-link">
-            <span class="glyphicon glyphicon-remove-circle" aria-hidden="true"></span>
-            Delete
-        </a>
+        {{ session.delete_button_nav() }}
     </li>
 {% endif %}
 </ul>

--- a/app/templates/session/view.html
+++ b/app/templates/session/view.html
@@ -106,9 +106,9 @@
     {% for member in session.participants %}
     <li>
         {% if member.player.id == current_user.id %}
-        <a href="{{ url_for('character.view', id=member.id) }}"><b>{{ member.name }}</b></a> (<a href="{{ url_for('character.journal_create', c_id=member.id, c_name=member.name|urlfriendly, session=session.id) }}">write Journal</a>)
+        {{ member.view_link(classes="own-char") }} (<a href="{{ url_for('character.journal_create', c_id=member.id, c_name=member.name|urlfriendly, session=session.id) }}">write Journal</a>)
         {% else %}
-        <a href="{{ url_for('character.view', id=member.id) }}">{{ member.name }}</a>
+        {{ member.view_link() }}
         {% endif %}
     </li>
     {% endfor %}
@@ -131,11 +131,7 @@
 
         by
 
-        {% if journal.character in session.participants %}
         {{ journal.character.name }}
-        {% else %}
-        <a href="{{ url_for('character.view', id=journal.character_id, name=journal.character.name|urlfriendly) }}">{{ journal.character.name }}</a>
-        {% endif %}
 
         {% if journal.character.player == current_user or current_user.has_admin_role() %}
         (<a href="{{ url_for('character.journal_edit', c_id=journal.character_id, j_id=journal.id, c_name=journal.character.name|urlfriendly, j_name=journal.title|urlfriendly) }}">edit Journal</a>)

--- a/app/templates/session/view.html
+++ b/app/templates/session/view.html
@@ -69,7 +69,7 @@
 
 {% if session.campaign %}
 <p>
-    This is session #{{ session.get_session_number() }} in <a href="{{ url_for('campaign.view', id=session.campaign_id, name=session.campaign.name|urlfriendly) }}">{{ session.campaign.name }}</a>.
+    This is session #{{ session.get_session_number() }} in {{ session.campaign.view_link() }}.
 </p>
 {% endif %}
 

--- a/app/templates/session/view.html
+++ b/app/templates/session/view.html
@@ -112,9 +112,9 @@
     {% if journal.is_visible or journal.character.player == current_user or current_user.has_admin_role() %}
     <li>
         {% if journal.is_visible %}
-        "<a href="{{ url_for('character.journal_view', c_id=journal.character_id, j_id=journal.id, c_name=journal.character.name|urlfriendly, j_name=journal.title|urlfriendly) }}">{{ journal.title }}</a>"
+        "{{ journal.view_link() }}"
         {% else %}
-        "<a class="invisible_item" href="{{ url_for('character.journal_view', c_id=journal.character_id, j_id=journal.id, c_name=journal.character.name|urlfriendly, j_name=journal.title|urlfriendly) }}">{{ journal.title }}</a>"
+        "{{ journal.view_link(classes="invisible_item") }}"
         {% endif %}
 
         by
@@ -122,7 +122,7 @@
         {{ journal.character.name }}
 
         {% if journal.character.player == current_user or current_user.has_admin_role() %}
-        (<a href="{{ url_for('character.journal_edit', c_id=journal.character_id, j_id=journal.id, c_name=journal.character.name|urlfriendly, j_name=journal.title|urlfriendly) }}">edit Journal</a>)
+        ({{ journal.edit_link(text="edit") }})
         {% endif %}
     </li>
     {% endif %}

--- a/app/templates/user/list.html
+++ b/app/templates/user/list.html
@@ -61,14 +61,8 @@ makeDatatable("user-table");
                     {% endif %}
                 </td>
                 <td>
-                    <a href="{{ url_for('user.profile', username=user.username) }}" class="btn btn-default">
-                        <span class="glyphicon glyphicon-user" aria-hidden="true"></span>
-                        Show Profile
-                    </a>
-                    <a href="{{ url_for('user.edit', username=user.username) }}" class="btn btn-default">
-                        <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-                        Edit
-                    </a>
+                    {{ user.view_button() }}
+                    {{ user.edit_button() }}
                 </td>
             </tr>
         {% endfor %}

--- a/app/templates/user/profile.html
+++ b/app/templates/user/profile.html
@@ -75,16 +75,10 @@
             <tr>
                 <td> {{ char.name }} ({{ char.race}} {{ char.class_ }})</td>
                 <td>
-                    <a href="{{ url_for('character.view', id=char.id, name=char.name|urlfriendly) }}" class="btn btn-default">
-                        <span class="glyphicon glyphicon-eye-open" aria-hidden="true"></span>
-                        View
-                    </a>
+                    {{ char.view_button() }}
 
                     {% if user == current_user or current_user.has_admin_role() %}
-                    <a href="{{ url_for('character.edit', id=char.id, name=char.name|urlfriendly) }}" class="btn btn-default">
-                        <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-                        Edit
-                    </a>
+                    {{ char.edit_button() }}
                     {% endif %}
                 </td>
             </tr>

--- a/app/templates/user/profile.html
+++ b/app/templates/user/profile.html
@@ -94,7 +94,7 @@
     </p>
     <ul class="list-unstyled">
         {% for campaign in user.campaigns %}
-        <li><a href="{{ url_for('campaign.view', id=campaign.id, name=campaign.name|urlfriendly) }}">{{ campaign.name }}</a></li>
+        <li>{{ campaign.view_link() }}</li>
         {% endfor %}
     </ul>
     {% endif %}

--- a/app/templates/user/profile.html
+++ b/app/templates/user/profile.html
@@ -21,10 +21,7 @@
     {% if user == current_user or current_user.has_admin_role() %}
     <ul class="nav nav-tabs">
         <li>
-            <a href="{{ url_for('user.edit', username=user.username) }}">
-                <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-                Edit Profile
-            </a>
+            {{ user.edit_button_nav() }}
         </li>
 
         {% if user == current_user  %}

--- a/app/templates/wiki/recent.html
+++ b/app/templates/wiki/recent.html
@@ -6,6 +6,8 @@
 {{ include_js(['moment']) }}
 {% endblock %}
 
+{# TODO use real objects here for view links and user links #}
+
 {% block app_content %}
     {{ super() }}
 

--- a/app/templates/wiki/view.html
+++ b/app/templates/wiki/view.html
@@ -30,10 +30,7 @@
         </a>
     </li>
     <li>
-        <a href="{{ url_for('wiki.edit', id=entry.id, name=entry.title|urlfriendly) }}">
-            <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-            Edit Article
-        </a>
+        {{ entry.edit_button_nav() }}
     </li>
 
     {% if current_user.is_wiki_admin() %}
@@ -50,10 +47,7 @@
     </li>
     {% if entry.id != 1 %}
     <li class="delete-li">
-        <a href="{{ url_for('wiki.delete', id=entry.id, name=entry.title|urlfriendly) }}" class="nav-danger" id="delete-link">
-            <span class="glyphicon glyphicon-remove-circle" aria-hidden="true"></span>
-            Delete
-        </a>
+        {{ entry.delete_button_nav() }}
     </li>
     {% endif %}
     {% endif %}

--- a/app/user/routes.py
+++ b/app/user/routes.py
@@ -62,7 +62,7 @@ def edit(username):
             db.session.commit()
             flash("Your changes have been saved.", "success")
 
-            return redirect(url_for("user.profile", username=username))
+            return redirect(user.view_url())
         elif request.method == "GET":
             form.about.data = user.about
 
@@ -99,7 +99,7 @@ def create():
         db.session.commit()
 
         flash("New user " + new_user.username + " created.", "success")
-        return redirect(url_for('user.profile', username=new_user.username))
+        return redirect(new_user.view_url())
     else:
         return render_template("user/create.html", form=form, title=page_title("Add User"))
 

--- a/app/wiki/routes.py
+++ b/app/wiki/routes.py
@@ -15,7 +15,6 @@ no_perm_url = "wiki.index"
 @login_required
 def index():
     return redirect(url_for("wiki.view", id=1, name=urlfriendly("Main Page")))
-    return redirect(url_for("wiki.view", id=1, name=urlfriendly("Main Page")))
 
 @bp.route("/create", methods=["GET", "POST"])
 @login_required

--- a/app/wiki/routes.py
+++ b/app/wiki/routes.py
@@ -15,6 +15,7 @@ no_perm_url = "wiki.index"
 @login_required
 def index():
     return redirect(url_for("wiki.view", id=1, name=urlfriendly("Main Page")))
+    return redirect(url_for("wiki.view", id=1, name=urlfriendly("Main Page")))
 
 @bp.route("/create", methods=["GET", "POST"])
 @login_required
@@ -47,7 +48,7 @@ def create():
         db.session.commit()
 
         flash("Wiki entry was added.", "success")
-        return redirect(url_for("wiki.view", id=entry.id, name=urlfriendly(entry.title)))
+        return redirect(entry.view_url())
     elif request.method == "GET":
         if current_user.is_wiki_admin():
             wsettings = WikiSetting.query.get(1)
@@ -99,7 +100,7 @@ def edit(id, name=None):
         db.session.commit()
         flash("Wiki entry was edited.", "success")
 
-        return redirect(url_for("wiki.view", id=id, name=urlfriendly(wikientry.title)))
+        return redirect(wikientry.view_url())
     elif request.method == "GET":
         if wikientry.id != 1:
             form.title.data = wikientry.title
@@ -178,7 +179,7 @@ def toggle_vis(id, name=None):
         flash("Article is now visible to anyone.", "success")
 
     db.session.commit()
-    return redirect(url_for('wiki.view', id=id, name=urlfriendly(wikientry.title)))
+    return redirect(wikientry.view_url())
 
 @bp.route("/search/<string:text>", methods=["GET"])
 @login_required

--- a/static_files/style.css
+++ b/static_files/style.css
@@ -162,7 +162,7 @@ body {
     margin-bottom:10px;
 }
 
-ul.nav-tabs li span.glyphicon {
+ul.nav-tabs li:not(.delete-li) span.glyphicon {
     color: #000 !important;
 }
 
@@ -255,12 +255,7 @@ ul.nav-tabs li span.glyphicon {
     color:#ab0000 !important;
 }
 
-a.nav-danger {
-    background-color:#c9302c;
-    color:#000;
-}
-
-a.nav-danger:hover {
+li.delete-li a:hover {
     background-color:#c90000 !important;
 }
 

--- a/static_files/style.css
+++ b/static_files/style.css
@@ -355,3 +355,7 @@ tr.invisible_item,
     background:#fafafa;
     margin:10px;
 }
+
+.own-char {
+    font-weight:bold;
+}


### PR DESCRIPTION
The idea was to make it possible for models to generate their own links, reduce code cluttering and also having a central point to define which Markup goes into a link. This worked only **partially**.

Problems:
1. Only basic links covered
I decided to (mostly) only cover the basic links view, edit and delete. The /new endpoint is never a member of a model (except for maybe Journal or MapNode), as such those links are still in the templates. Same goes for most special links like for example map.view_with_node. These links are rarely used anyway, it is probably only worth to implement when they are used multiple times (which of course might happen in the future)

2. Some models were not included
Particularly MapNode and MapNodeType were not yet included. They were not included in the friendly-links overhaul earlier. This should eventually be done, preferably when doing some general map overhaul like #11 .

3. Templates not using objects
The wiki and especially the sidebars do not use full objects, as such these functions can not be used.  The easiest fix for the sidebars would be serverside generation, which is planned in #13 anyway. The Wiki navigation will probably be overhauled in #7, so the new functions could be used there.

For now, I am still content. This seems like a convenient way to harmonize link generation, especially for some models like Campaign or Event(Category), where the color will now be displaying in-link.

Implements #10.

