### PR TITLE
Use fontawesome instead of glyphicons

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -208,7 +208,17 @@ def utility_processor():
     def get_archivar_version():
         return version()
 
-    return dict(load_global_quicklinks=load_global_quicklinks, load_user_quicklinks=load_user_quicklinks, include_css=include_css, include_js=include_js, get_archivar_version=get_archivar_version)
+    def icon(name):
+        from app.helpers import icon as icon_fkt
+
+        return icon_fkt(name)
+
+    return dict(load_global_quicklinks=load_global_quicklinks,
+                load_user_quicklinks=load_user_quicklinks,
+                include_css=include_css,
+                include_js=include_js,
+                get_archivar_version=get_archivar_version,
+                icon=icon)
 
 @app.template_filter()
 def hash(text):

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,6 +6,7 @@ from flask_login import LoginManager, current_user
 from flask_bootstrap import Bootstrap, StaticCDN
 from flask_moment import Moment
 from flask_misaka import Misaka
+from flask_fontawesome import FontAwesome
 from jinja2 import Markup
 from sqlalchemy import MetaData
 from app.version import version
@@ -28,6 +29,7 @@ login.login_view = 'login'
 bootstrap = Bootstrap(app)
 markdown = Misaka(app, tables=True, fenced_code=True, escape=True)
 moment = Moment(app)
+fontawesome = FontAwesome(app)
 
 # override ConditionalCDN with StaticCDN if local serve is wanted
 # reason: using the usual local cdn results in a 404 for bootstrap.min.css.map on every page

--- a/app/helpers.py
+++ b/app/helpers.py
@@ -221,4 +221,4 @@ def urlfriendly(text):
     return text
 
 def icon(name):
-    return Markup('<span class="glyphicon glyphicon-{}" aria-hidden="true"></span>'.format(name))
+    return Markup('<span class="fas fa-{}" aria-hidden="true"></span>'.format(name))

--- a/app/helpers.py
+++ b/app/helpers.py
@@ -2,6 +2,7 @@ from flask import flash, redirect, url_for
 from functools import wraps
 from app import db
 from flask_login import current_user
+from jinja2 import Markup
 from sqlalchemy import func
 from wtforms.validators import ValidationError
 
@@ -218,3 +219,6 @@ def urlfriendly(text):
             text = text[:idx]
 
     return text
+
+def icon(name):
+    return Markup('<span class="glyphicon glyphicon-{}" aria-hidden="true"></span>'.format(name))

--- a/app/models.py
+++ b/app/models.py
@@ -132,22 +132,22 @@ class LinkGenerator(object):
 
         return self.link(self.delete_url(), text, classes, ids)
 
-    def view_button(self, text="View", icon="eye-open", classes="btn btn-default", ids=None, swap=False):
+    def view_button(self, text="View", icon="eye", classes="btn btn-default", ids=None, swap=False):
         return self.button(self.view_url(), text, icon, classes, ids, swap)
 
-    def edit_button(self, text="Edit", icon="pencil", classes="btn btn-default", ids=None, swap=False):
+    def edit_button(self, text="Edit", icon="edit", classes="btn btn-default", ids=None, swap=False):
         return self.button(self.edit_url(), text, icon, classes, ids, swap)
 
-    def delete_button(self, text="Delete", icon="remove-circle", classes="btn btn-danger", ids="delete-link", swap=False):
+    def delete_button(self, text="Delete", icon="trash-alt", classes="btn btn-danger", ids="delete-link", swap=False):
         return self.button(self.delete_url(), text, icon, classes, ids, swap)
 
-    def view_button_nav(self, text="View", icon="eye-open", classes=None, ids=None, swap=False):
+    def view_button_nav(self, text="View", icon="eye", classes=None, ids=None, swap=False):
         return self.button(self.view_url(), text, icon, classes, ids, swap)
 
-    def edit_button_nav(self, text="Edit", icon="pencil", classes=None, ids=None, swap=False):
+    def edit_button_nav(self, text="Edit", icon="edit", classes=None, ids=None, swap=False):
         return self.button(self.edit_url(), text, icon, classes, ids, swap)
 
-    def delete_button_nav(self, text="Delete", icon="remove-circle", classes="btn btn-danger", ids="delete-link", swap=False):
+    def delete_button_nav(self, text="Delete", icon="trash-alt", classes="btn btn-danger", ids="delete-link", swap=False):
         return self.button(self.delete_url(), text, icon, classes, ids, swap)
 
     def view_text(self):

--- a/app/models.py
+++ b/app/models.py
@@ -1,5 +1,5 @@
 from app import app, db, login
-from app.helpers import urlfriendly
+from app.helpers import urlfriendly, icon as icon_fkt
 from datetime import datetime
 from flask import url_for
 from flask_login import UserMixin
@@ -103,7 +103,7 @@ class LinkGenerator(object):
 
     def button(self, url, text, icon=None, classes=None, ids=None, swap=False):
         if icon != None:
-            icon = '<span class="glyphicon glyphicon-{}" aria-hidden="true"></span>'.format(icon)
+            icon = icon_fkt(icon)
 
         if swap == False:
             text = "{}\n{}".format(icon, text)

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -46,15 +46,15 @@ $(document).ready(function() {
         <div class="navbar-collapse collapse" id="topnav-navbar">
             <ul class="nav navbar-nav navbar-left" id="leftnav">
                 <li><a href="{{ url_for('index') }}">
-                    <span class="glyphicon glyphicon-home"></span>
+                    {{ icon("home") }}
                 </a></li>
 
                 {% if current_user.is_authenticated %}
-                <li><a href="{{ url_for('campaign.index') }}"><span class="glyphicon glyphicon-book"></span> Campaigns</a></li>
-                <li><a href="{{ url_for('session.index') }}"><span class="glyphicon glyphicon-pencil"></span> Sessions</a></li>
-                <li><a href="{{ url_for('map.index') }}"><span class="glyphicon glyphicon-map-marker"></span> Map</a></li>
-                <li><a href="{{ url_for('wiki.index') }}"><span class="glyphicon glyphicon-education"></span> Wiki</a></li>
-                <li><a href="{{ url_for('calendar.index') }}"><span class="glyphicon glyphicon-calendar"></span> Calendar</a></li>
+                <li><a href="{{ url_for('campaign.index') }}">{{ icon("book") }} Campaigns</a></li>
+                <li><a href="{{ url_for('session.index') }}">{{ icon("pencil") }} Sessions</a></li>
+                <li><a href="{{ url_for('map.index') }}">{{ icon("map-marker") }} Map</a></li>
+                <li><a href="{{ url_for('wiki.index') }}">{{ icon("education") }} Wiki</a></li>
+                <li><a href="{{ url_for('calendar.index') }}">{{ icon("calendar") }} Calendar</a></li>
                 {% endif %}
 
             </ul>
@@ -70,7 +70,7 @@ $(document).ready(function() {
                     {% elif user_ql|length > 1 %}
                 <li class="dropdown user-quicklinks">
                     <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
-                    <span class="glyphicon glyphicon-flash"></span> Quicklinks <span class="caret"></span>
+                    {{ icon("flash") }} Quicklinks <span class="caret"></span>
                     </a>
                     <ul class="dropdown-menu">
                         {% for link in user_ql %}
@@ -78,7 +78,7 @@ $(document).ready(function() {
                         {% endfor %}
                         <li role="separator" class="divider"></li>
                         <li><a href="{{ url_for('user.settings') }}">
-                            <span class="glyphicon glyphicon-cog"></span>
+                            {{ icon("cog") }}
                             Edit quicklinks
                             </a>
                         </li>
@@ -95,17 +95,17 @@ $(document).ready(function() {
 
             <ul class="nav navbar-nav navbar-right">
                 {% if current_user.is_authenticated %}
-                <li><a href="{{ url_for('media.index') }}"><span class="glyphicon glyphicon-picture"></span> Media</a></li>
+                <li><a href="{{ url_for('media.index') }}">{{ icon("picture") }} Media</a></li>
                 {% endif %}
 
                 {% if current_user.is_authenticated %}
-                <li><a href="{{ url_for('character.list') }}"><span class="glyphicon glyphicon-list"></span> Parties & Chars</a></li>
+                <li><a href="{{ url_for('character.list') }}">{{ icon("list") }} Parties & Chars</a></li>
                 {% endif %}
 
                 {% if current_user.is_authenticated and current_user.has_admin_role() %}
                 <li class="dropdown">
                     <a href="{{ url_for('user.list') }}">
-                    <span class="glyphicon glyphicon-user" id="users-glyph"></span> Users
+                    {{ icon("user") }} Users
                     </a>
                 </li>
                 {% endif %}
@@ -113,7 +113,7 @@ $(document).ready(function() {
                 {% if current_user.is_authenticated and current_user.has_access_to_some_settings() %}
                 <li class="dropdown">
                     <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
-                    <span class="glyphicon glyphicon-cog"></span> Settings <span class="caret"></span>
+                    {{ icon("cog") }} Settings <span class="caret"></span>
                     </a>
                     <ul class="dropdown-menu">
                         {% if current_user.has_admin_role() %}
@@ -151,7 +151,7 @@ $(document).ready(function() {
                 {% else %}
                 <li class="dropdown">
                     <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
-                    <span class="glyphicon glyphicon-user"></span> {{ current_user.username }} <span class="caret"></span>
+                    {{ icon("user") }} {{ current_user.username }} <span class="caret"></span>
                     </a>
                     <ul class="dropdown-menu">
                         <li>{{ current_user.view_link() }}</li>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -13,6 +13,7 @@
 {{ super() }}
 <link rel="icon" href="{{ url_for('static_files', filename='favicon.ico') }}" type="image/x-icon">
 <link rel="stylesheet" type="text/css" href="{{ url_for('static_files', filename='style.css') }}">
+{{ fontawesome_css() }}
 
 <style type="text/css">
 .CodeMirror {
@@ -23,6 +24,8 @@
 
 {% block scripts %}
 {{ super() }}
+
+{{ fontawesome_js() }}
 
 <script type="text/javascript">
 $(document).ready(function() {
@@ -51,10 +54,10 @@ $(document).ready(function() {
 
                 {% if current_user.is_authenticated %}
                 <li><a href="{{ url_for('campaign.index') }}">{{ icon("book") }} Campaigns</a></li>
-                <li><a href="{{ url_for('session.index') }}">{{ icon("pencil") }} Sessions</a></li>
-                <li><a href="{{ url_for('map.index') }}">{{ icon("map-marker") }} Map</a></li>
-                <li><a href="{{ url_for('wiki.index') }}">{{ icon("education") }} Wiki</a></li>
-                <li><a href="{{ url_for('calendar.index') }}">{{ icon("calendar") }} Calendar</a></li>
+                <li><a href="{{ url_for('session.index') }}">{{ icon("file") }} Sessions</a></li>
+                <li><a href="{{ url_for('map.index') }}">{{ icon("map-marker-alt") }} Map</a></li>
+                <li><a href="{{ url_for('wiki.index') }}">{{ icon("graduation-cap") }} Wiki</a></li>
+                <li><a href="{{ url_for('calendar.index') }}">{{ icon("calendar-alt") }} Calendar</a></li>
                 {% endif %}
 
             </ul>
@@ -70,7 +73,7 @@ $(document).ready(function() {
                     {% elif user_ql|length > 1 %}
                 <li class="dropdown user-quicklinks">
                     <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
-                    {{ icon("flash") }} Quicklinks <span class="caret"></span>
+                    {{ icon("bolt") }} Quicklinks <span class="caret"></span>
                     </a>
                     <ul class="dropdown-menu">
                         {% for link in user_ql %}
@@ -95,7 +98,7 @@ $(document).ready(function() {
 
             <ul class="nav navbar-nav navbar-right">
                 {% if current_user.is_authenticated %}
-                <li><a href="{{ url_for('media.index') }}">{{ icon("picture") }} Media</a></li>
+                <li><a href="{{ url_for('media.index') }}">{{ icon("images") }} Media</a></li>
                 {% endif %}
 
                 {% if current_user.is_authenticated %}
@@ -105,7 +108,7 @@ $(document).ready(function() {
                 {% if current_user.is_authenticated and current_user.has_admin_role() %}
                 <li class="dropdown">
                     <a href="{{ url_for('user.list') }}">
-                    {{ icon("user") }} Users
+                    {{ icon("users") }} Users
                     </a>
                 </li>
                 {% endif %}

--- a/app/templates/calendar/index.html
+++ b/app/templates/calendar/index.html
@@ -11,13 +11,13 @@ The calendar has not been finalized by the admin yet.
 <ul class="nav nav-tabs">
     <li>
         <a href="{{ url_for('calendar.view') }}">
-            <span class="glyphicon glyphicon-calendar" aria-hidden="true"></span>
+            {{ icon("calendar") }}
             View Info
         </a>
     </li>
     <li>
         <a href="{{ url_for('event.create') }}">
-            <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+            {{ icon("plus") }}
             Add Event
         </a>
     </li>
@@ -25,7 +25,7 @@ The calendar has not been finalized by the admin yet.
     {% if current_user.has_admin_role() %}
     <li>
         <a href="{{ url_for('calendar.settings') }}">
-            <span class="glyphicon glyphicon-cog" aria-hidden="true"></span>
+            {{ icon("cog") }}
             Calendar Settings
         </a>
     </li>
@@ -34,7 +34,7 @@ The calendar has not been finalized by the admin yet.
     {% if current_user.is_event_admin() %}
      <li>
         <a href="{{ url_for('event.settings') }}">
-            <span class="glyphicon glyphicon-cog" aria-hidden="true"></span>
+            {{ icon("cog") }}
             Event Settings
         </a>
     </li>

--- a/app/templates/calendar/preview.html
+++ b/app/templates/calendar/preview.html
@@ -31,13 +31,13 @@ $("#phase-button").click(function(e) {
     <ul class="nav nav-tabs">
         <li>
             <a href="{{ url_for('calendar.settings') }}">
-                <span class="glyphicon glyphicon-arrow-left" aria-hidden="true"></span>
+                {{ icon("arrow-left") }}
                 Back to Settings
             </a>
         </li>
          <li id="finalize-btn">
             <a href="{{ url_for('calendar.finalize') }}">
-                <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+                {{ icon("exclamation-sign") }}
                 Finalize
             </a>
         </li>
@@ -159,7 +159,7 @@ $("#phase-button").click(function(e) {
     <ul class="nav nav-tabs">
         <li>
             <a href="" id="phase-button">
-                <span class="glyphicon glyphicon-adjust" aria-hidden="true"></span>
+                {{ icon("adjust") }}
                 Toggle moon phases
             </a>
         </li>

--- a/app/templates/calendar/settings.html
+++ b/app/templates/calendar/settings.html
@@ -7,7 +7,7 @@
 <ul class="nav nav-tabs">
     <li>
         <a href="{{ url_for('calendar.view') }}">
-            <span class="glyphicon glyphicon-calendar" aria-hidden="true"></span>
+            {{ icon("calendar") }}
             Public calendar info
         </a>
     </li>
@@ -20,13 +20,13 @@ The calendar was finalized, which means no alterations can be made, except for t
 <ul class="nav nav-tabs">
     <li>
         <a href="{{ url_for('calendar.check') }}">
-            <span class="glyphicon glyphicon-check" aria-hidden="true"></span>
+            {{ icon("check") }}
             Check Constraints
         </a>
     </li>
     <li>
         <a href="{{ url_for('calendar.preview') }}">
-            <span class="glyphicon glyphicon-sunglasses" aria-hidden="true"></span>
+            {{ icon("sunglasses") }}
             Preview Calendar
         </a>
     </li>
@@ -56,7 +56,7 @@ Events can only be created after the calendar is finalized.
 <ul class="nav nav-tabs">
     <li>
         <a href="{{ url_for('calendar.epoch_create') }}">
-            <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+            {{ icon("plus") }}
             Add Epoch
         </a>
     </li>
@@ -107,11 +107,11 @@ For a valid calendar, only the bottom-most epoch can have a duration of 0.
 
                 {% if settings.finalized == False %}
                 <a href="{{ url_for('calendar.epoch_up', id=epoch.id, name=epoch.name|urlfriendly) }}" class="btn btn-default">
-                    <span class="glyphicon glyphicon-arrow-up" aria-hidden="true"></span>
+                    {{ icon("arrow-up") }}
                 </a>
 
                 <a href="{{ url_for('calendar.epoch_down', id=epoch.id, name=epoch.name|urlfriendly) }}" class="btn btn-default">
-                    <span class="glyphicon glyphicon-arrow-down" aria-hidden="true"></span>
+                    {{ icon("arrow-down") }}
                 </a>
 
                 {{ epoch.delete_button() }}
@@ -135,7 +135,7 @@ For a valid calendar, only the bottom-most epoch can have a duration of 0.
 <ul class="nav nav-tabs">
     <li>
         <a href="{{ url_for('calendar.month_create') }}">
-            <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+            {{ icon("plus") }}
             Add Month
         </a>
     </li>
@@ -176,11 +176,11 @@ For a valid calendar, at least one month must be defined and each month must hav
 
                 {% if settings.finalized == False %}
                 <a href="{{ url_for('calendar.month_up', id=month.id, name=month.name|urlfriendly) }}" class="btn btn-default">
-                    <span class="glyphicon glyphicon-arrow-up" aria-hidden="true"></span>
+                    {{ icon("arrow-up") }}
                 </a>
 
                 <a href="{{ url_for('calendar.month_down', id=month.id, name=month.name|urlfriendly) }}" class="btn btn-default">
-                    <span class="glyphicon glyphicon-arrow-down" aria-hidden="true"></span>
+                    {{ icon("arrow-down") }}
                 </a>
 
                 {{ month.delete_button() }}
@@ -206,7 +206,7 @@ For a valid calendar, at least one month must be defined and each month must hav
 <ul class="nav nav-tabs">
     <li>
         <a href="{{ url_for('calendar.day_create') }}">
-            <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+            {{ icon("plus") }}
             Add Day
         </a>
     </li>
@@ -242,11 +242,11 @@ For a valid calendar, at least one day must be defined.
 
                 {% if settings.finalized == False %}
                 <a href="{{ url_for('calendar.day_up', id=day.id, name=day.name|urlfriendly) }}" class="btn btn-default">
-                    <span class="glyphicon glyphicon-arrow-up" aria-hidden="true"></span>
+                    {{ icon("arrow-up") }}
                 </a>
 
                 <a href="{{ url_for('calendar.day_down', id=day.id, name=day.name|urlfriendly) }}" class="btn btn-default">
-                    <span class="glyphicon glyphicon-arrow-down" aria-hidden="true"></span>
+                    {{ icon("arrow-down") }}
                 </a>
 
                 {{ day.delete_button() }}
@@ -271,7 +271,7 @@ For a valid calendar, at least one day must be defined.
 <ul class="nav nav-tabs">
     <li>
         <a href="{{ url_for('calendar.moon_create') }}">
-            <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+            {{ icon("plus") }}
             Add Moon
         </a>
     </li>

--- a/app/templates/calendar/view.html
+++ b/app/templates/calendar/view.html
@@ -178,7 +178,7 @@ $("#phase-button").click(function(e) {
     <ul class="nav nav-tabs">
         <li>
             <a href="" id="phase-button">
-                <span class="glyphicon glyphicon-adjust" aria-hidden="true"></span>
+                {{ icon("adjust") }}
                 Toggle Moon Phases
             </a>
         </li>

--- a/app/templates/campaign/list.html
+++ b/app/templates/campaign/list.html
@@ -27,7 +27,7 @@ makeDatatable("campaigns-table");
     <ul class="nav nav-tabs">
         <li>
             <a href="{{ url_for('campaign.create') }}">
-                <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+                {{ icon("plus") }}
                 Add Campaign
             </a>
         </li>
@@ -62,7 +62,7 @@ makeDatatable("campaigns-table");
                     {{ campaign.edit_button() }}
 
                     <a href="{{ url_for('session.create_with_campaign', id=campaign.id) }}" class="btn btn-default">
-                        <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+                        {{ icon("plus") }}
                         Add Session
                     </a>
                     {% endif %}

--- a/app/templates/campaign/view.html
+++ b/app/templates/campaign/view.html
@@ -23,7 +23,7 @@ makeDatatable("sessions-table");
 <ul class="nav nav-tabs">
     <li>
         <a href="{{ url_for('session.create', base=campaign.id) }}">
-            <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+            {{ icon("plus") }}
             Add Session
         </a>
     </li>

--- a/app/templates/character/journal_list.html
+++ b/app/templates/character/journal_list.html
@@ -17,7 +17,7 @@
 {% if current_user == char.player %}
     <li>
         <a href="{{ url_for('character.journal_create', c_id=char.id, c_name=char.name|urlfriendly) }}">
-            <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+            {{ icon("plus") }}
             Add Entry
         </a>
     </li>

--- a/app/templates/character/list.html
+++ b/app/templates/character/list.html
@@ -36,7 +36,7 @@ makeDatatable("parties-table", 5);
 <ul class="nav nav-tabs">
     <li>
         <a href="{{ url_for('party.create') }}">
-            <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+            {{ icon("plus") }}
             Add Party
         </a>
     </li>
@@ -83,7 +83,7 @@ makeDatatable("parties-table", 5);
 <ul class="nav nav-tabs">
     <li>
         <a href="{{ url_for('character.create') }}">
-            <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+            {{ icon("plus") }}
             Add Character
         </a>
     </li>

--- a/app/templates/character/view.html
+++ b/app/templates/character/view.html
@@ -39,7 +39,7 @@
         {% if current_user == char.player %}
         <li>
             <a href="{{ url_for('character.journal_create', c_id=char.id, c_name=char.name|urlfriendly) }}">
-                <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+                {{ icon("plus") }}
                 Add Journal Entry
             </a>
         </li>
@@ -47,7 +47,7 @@
         {% if char.journals %}
         <li>
             <a href="{{ url_for('character.journal_list', c_id=char.id, c_name=char.name|urlfriendly) }}">
-                <span class="glyphicon glyphicon-book" aria-hidden="true"></span>
+                {{ icon("book") }}
                 View Full Journal
             </a>
         </li>

--- a/app/templates/event/list.html
+++ b/app/templates/event/list.html
@@ -28,7 +28,7 @@ makeDatatable("event-table");
         {% elif category_flag %}
             <a href="{{ url_for('event.create', category=request.view_args['c_id']) }}">
         {% endif %}
-                <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+                {{ icon("plus") }}
                 Add Event here
             </a>
         </li>

--- a/app/templates/event/settings.html
+++ b/app/templates/event/settings.html
@@ -31,7 +31,7 @@
 <ul class="nav nav-tabs">
     <li>
         <a href="{{ url_for('event.category_create') }}">
-            <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+            {{ icon("plus") }}
             Add Category
         </a>
     </li>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -5,7 +5,7 @@
     <ul class="nav nav-tabs">
         <li>
             <a href="{{ url_for('settings') }}">
-                <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
+                {{ icon("pencil") }}
                 Edit Text
             </a>
         </li>

--- a/app/templates/map/index.html
+++ b/app/templates/map/index.html
@@ -20,14 +20,14 @@
   <div id="messagebox"></div>
   <div id="nodeform" class="panel">
     <a class="close-link">
-      <span class="glyphicon glyphicon-remove"></span>
+      {{ icon("remove") }}
     </a>
     <div id="nodeform_content"></div>
   </div>
 
   <div id="location-list">
     <a class="close-link-sidebar">
-      <span class="glyphicon glyphicon-remove"></span>
+      {{ icon("remove") }}
     </a>
     <input type="text" id="filter_locations" placeholder="filter" />
     <ul id="locations"></ul>
@@ -38,27 +38,27 @@
   </span>
 
   <a id="btn-loc-sidebar" class="btn btn-default btn-left">
-    <span class="glyphicon glyphicon-list"></span>
+    {{ icon("list") }}
     Location List
   </a>
 
   <div id="bottom-right-buttons">
     <a id="btn-add-node" class="btn btn-default">
-      <span class="glyphicon glyphicon-plus"></span>
+      {{ icon("plus") }}
       Add Location
     </a>
 
     <a id="btn-cancel-add-node" class="btn btn-warning">
-      <span class="glyphicon glyphicon-remove"></span>
+      {{ icon("remove") }}
       Cancel
     </a>
   {% if current_user.has_admin_role() %}
     <a id="btn-add-node" class="btn btn-default" href="{{ url_for('map.create') }}">
-      <span class="glyphicon glyphicon-plus"></span>
+      {{ icon("plus") }}
       Add Map
     </a>
     <a id="btn-settings" class="btn btn-default" href="{{ url_for('map.list') }}">
-      <span class="glyphicon glyphicon-list"></span>
+      {{ icon("list") }}
       Ĺist
     </a>
     {{ map_.settings_button(ids="btn-settings") }}
@@ -521,22 +521,22 @@
 
       if (wiki_id != 0 && wiki_id != null) {
         var fake_url = "{{ url_for('wiki.view', id=-1) }}"
-        pop.append('<a href="' + fake_url.replace("-1", wiki_id) + '" class="btn btn-default"><span class="glyphicon glyphicon-education"></span> Wiki article</a> ');
+        pop.append('<a href="' + fake_url.replace("-1", wiki_id) + '" class="btn btn-default">{{ icon("education") }} Wiki article</a> ');
       }
 
       if (submap_id != 0 && submap_id != null) {
         var fake_url = "{{ url_for('map.view', id=-1) }}"
-        pop.append('<a href="' + fake_url.replace("-1", submap_id) + '" class="btn btn-default"><span class="glyphicon glyphicon-map-marker"></span> View map</a>');
+        pop.append('<a href="' + fake_url.replace("-1", submap_id) + '" class="btn btn-default">{{ icon("map-marker") }} View map</a>');
       }
 
       pop.append($('<div />').addClass("popup-markdown").append(description));
 
       var edit_btn = $("<a />").addClass("btn btn-default node-edit-btn").attr("data", id);
-      edit_btn.append('<span class="glyphicon glyphicon-pencil"></span>');
+      edit_btn.append('{{ icon("pencil") }}');
       edit_btn.append(' edit');
 
       var delete_btn = $("<a />").addClass("btn btn-danger node-delete-btn").attr("data", id).css("float", "right");
-      delete_btn.append('<span class="glyphicon glyphicon-remove-circle"></span>');
+      delete_btn.append('{{ icon("remove-circle") }}');
       delete_btn.append(' delete');
 
       var btns = $("<nav />").append(edit_btn);

--- a/app/templates/map/list.html
+++ b/app/templates/map/list.html
@@ -27,7 +27,7 @@ makeDatatable("map-table");
 <ul class="nav nav-tabs">
     <li>
         <a href="{{ url_for('map.create') }}">
-            <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+            {{ icon("plus") }}
             Add Map
         </a>
     </li>

--- a/app/templates/map/node_edit.html
+++ b/app/templates/map/node_edit.html
@@ -8,7 +8,7 @@
     <div id="form_messagebox"></div>
     {{ wtf.quick_form(form) }}
     <a class="btn btn-default" id="btn-move-node" data="{{ node.id }}" style="float:right;">
-        <span class="glyphicon glyphicon-move"></span>
+        {{ icon("move") }}
         Move Location
     </a>
 </div>

--- a/app/templates/map/settings.html
+++ b/app/templates/map/settings.html
@@ -12,13 +12,13 @@
     <ul class="nav nav-tabs">
         <li>
             <a href="{{ url_for('map.create') }}">
-                <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+                {{ icon("plus") }}
                 Add Map
             </a>
         </li>
         <li>
             <a href="{{ url_for('map.list') }}">
-                <span class="glyphicon glyphicon-list" aria-hidden="true"></span>
+                {{ icon("list") }}
                 Map List
             </a>
         </li>
@@ -50,7 +50,7 @@
     <ul class="nav nav-tabs">
         <li>
             <a href="{{ url_for('map.node_type_create')}}">
-                <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+                {{ icon("plus") }}
                 Add Location Type
             </a>
         </li>
@@ -83,7 +83,7 @@
                 </td>
                 <td>
                     <a href="{{ url_for('map.node_type_edit', id=node_type.id) }}" class="btn btn-default">
-                        <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
+                        {{ icon("pencil") }}
                         Edit
                     </a>
                 </td>

--- a/app/templates/media/index.html
+++ b/app/templates/media/index.html
@@ -25,7 +25,7 @@ makeDatatable("media-table", 25, 25);
     <ul class="nav nav-tabs">
         <li>
             <a href="{{ url_for('media.upload') }}">
-                <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+                {{ icon("plus") }}
                 Add File
             </a>
         </li>
@@ -33,7 +33,7 @@ makeDatatable("media-table", 25, 25);
         {% if current_user.is_media_admin() %}
         <li>
             <a href="{{ url_for('media.settings') }}">
-                <span class="glyphicon glyphicon-cog" aria-hidden="true"></span>
+                {{ icon("cog") }}
                 Media Settings
             </a>
         </li>

--- a/app/templates/media/list.html
+++ b/app/templates/media/list.html
@@ -25,7 +25,7 @@ makeDatatable("media-table", 25, 25);
     <ul class="nav nav-tabs">
         <li>
             <a href="{{ url_for('media.upload', category=cat.id) }}">
-                <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+                {{ icon("plus") }}
                 New Media here
             </a>
         </li>

--- a/app/templates/media/settings.html
+++ b/app/templates/media/settings.html
@@ -31,7 +31,7 @@
 <ul class="nav nav-tabs">
     <li>
         <a href="{{ url_for('media.category_create') }}">
-            <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+            {{ icon("plus") }}
             New Category
         </a>
     </li>

--- a/app/templates/session/create.html
+++ b/app/templates/session/create.html
@@ -26,7 +26,7 @@ moment.updateLocale('en', {
 
 $("#date").wrap('<div class="input-group date" id="datetimepicker"></div>');
 iga = $("<span/>").addClass("input-group-addon");
-$("<span/>").addClass("glyphicon glyphicon-calendar").appendTo(iga);
+$("<span/>").addClass("fas fa-calendar").appendTo(iga);
 iga.appendTo($("#datetimepicker"));
 
 var dateformat_string = "YYYY-MM-DD HH:mm"

--- a/app/templates/session/edit.html
+++ b/app/templates/session/edit.html
@@ -26,7 +26,7 @@ moment.updateLocale('en', {
 
 $("#date").wrap('<div class="input-group date" id="datetimepicker"></div>');
 iga = $("<span/>").addClass("input-group-addon");
-$("<span/>").addClass("glyphicon glyphicon-calendar").appendTo(iga);
+$("<span/>").addClass("fas fa-calendar").appendTo(iga);
 iga.appendTo($("#datetimepicker"));
 
 var dateformat_string = "YYYY-MM-DD HH:mm";

--- a/app/templates/session/list.html
+++ b/app/templates/session/list.html
@@ -48,7 +48,7 @@ $(document).ready(function() {
             {% else %}
             <a href="{{ url_for('session.create') }}" id="add-session-button">
             {% endif %}
-                <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+                {{ icon("plus") }}
                 Add Session
             </a>
         </li>

--- a/app/templates/session/view.html
+++ b/app/templates/session/view.html
@@ -42,7 +42,7 @@
 {% elif current_user.has_admin_role() or current_user.is_dm_of(session.campaign) %}
     <li>
         <a href="{{ url_for('session.create_with_campaign', id=session.campaign_id) }}">
-            <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+            {{ icon("plus") }}
             Add Follow-Up Session
         </a>
     </li>

--- a/app/templates/sidebars.js
+++ b/app/templates/sidebars.js
@@ -288,21 +288,21 @@ function insertMedia(editor, name, id, filename, file_ext) {
 var reference = {
     name: "insertReference",
     action: toggleIntRefSidebar,
-    className: "fa fa-star fa-red",
+    className: "fas fa-star fa-red",
     title: "Insert internal reference",
 }
 
 var media = {
     name: "insertMedia",
     action: toggleMediaSidebar,
-    className: "fa fa-image fa-red",
+    className: "fas fa-image fa-red",
     title: "Insert media"
 }
 
 var maps = {
     name: "insertMapNode",
     action: toggleMapSidebar,
-    className: "fa fa-map-marker fa-red",
+    className: "fas fa-map-marker-alt fa-red",
     title: "Insert map node"
 }
 

--- a/app/templates/simplemde_sidebar.html
+++ b/app/templates/simplemde_sidebar.html
@@ -1,7 +1,7 @@
 {% if current_user.is_authenticated %}
 <div class="sidebar" id="intref-sidebar">
     <a class="close-link-sidebar">
-        <span class="glyphicon glyphicon-remove"></span>
+        {{ icon("remove") }}
     </a>
     <input type="text" id="filter_things" placeholder="filter" />
     <ul class="itemlist"></ul>
@@ -9,7 +9,7 @@
 
 <div class="sidebar" id="media-sidebar">
     <a class="close-link-sidebar">
-        <span class="glyphicon glyphicon-remove"></span>
+        {{ icon("remove") }}
     </a>
     <input type="text" id="filter_media" placeholder="filter" />
 
@@ -32,7 +32,7 @@
 
 <div class="sidebar" id="map-sidebar">
     <a class="close-link-sidebar">
-        <span class="glyphicon glyphicon-remove"></span>
+        {{ icon("remove") }}
     </a>
     <input type="text" id="filter_mapnodes" placeholder="filter" />
     <ul class="itemlist"></ul>

--- a/app/templates/user/list.html
+++ b/app/templates/user/list.html
@@ -20,7 +20,7 @@ makeDatatable("user-table");
     <ul class="nav nav-tabs">
         <li>
             <a href="{{ url_for('user.create') }}">
-                <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+                {{ icon("plus") }}
                 Add User
             </a>
         </li>

--- a/app/templates/user/profile.html
+++ b/app/templates/user/profile.html
@@ -27,13 +27,13 @@
         {% if user == current_user  %}
         <li>
             <a href="{{ url_for('user.settings') }}">
-                <span class="glyphicon glyphicon-cog"></span>
+                {{ icon("cog") }}
                 Settings
             </a>
         </li>
         <li>
             <a href="{{ url_for('character.create') }}">
-                <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+                {{ icon("plus") }}
                 Add Character
             </a>
         </li>

--- a/app/templates/wiki/view.html
+++ b/app/templates/wiki/view.html
@@ -37,10 +37,10 @@
     <li>
         <a href="{{ url_for('wiki.toggle_vis', id=entry.id, name=entry.title|urlfriendly) }}">
             {% if entry.is_visible %}
-            {{ icon("eye-close") }}
+            {{ icon("eye-slash") }}
             Hide Article
             {% else %}
-            {{ icon("eye-open") }}
+            {{ icon("eye") }}
             Make Public
             {% endif %}
         </a>

--- a/app/templates/wiki/view.html
+++ b/app/templates/wiki/view.html
@@ -25,7 +25,7 @@
 <ul class="nav nav-tabs">
     <li>
         <a href="{{ url_for('wiki.create') }}">
-            <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+            {{ icon("plus") }}
             Add Article
         </a>
     </li>
@@ -37,10 +37,10 @@
     <li>
         <a href="{{ url_for('wiki.toggle_vis', id=entry.id, name=entry.title|urlfriendly) }}">
             {% if entry.is_visible %}
-            <span class="glyphicon glyphicon-eye-close" aria-hidden="true"></span>
+            {{ icon("eye-close") }}
             Hide Article
             {% else %}
-            <span class="glyphicon glyphicon-eye-open" aria-hidden="true"></span>
+            {{ icon("eye-open") }}
             Make Public
             {% endif %}
         </a>

--- a/config.py
+++ b/config.py
@@ -21,4 +21,7 @@ class Config(object):
 
     # True: Use local js and css files, False: use CDNs
     # used for ALL external css/js, not just boostrap
-    BOOTSTRAP_SERVE_LOCAL = True
+    SERVE_LOCAL = True
+
+    BOOTSTRAP_SERVE_LOCAL = SERVE_LOCAL
+    FONTAWESOME_SERVE_LOCAL = SERVE_LOCAL

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ decorator==4.3.0
 dominate==2.3.1
 Flask==1.0.2
 Flask-Bootstrap==3.3.7.1
+Flask-FontAwesome==0.1.4
 Flask-Login==0.4.1
 Flask-Migrate==2.2.1
 Flask-Misaka==1.0.0

--- a/static_files/style.css
+++ b/static_files/style.css
@@ -150,14 +150,6 @@ body {
     border-top:2px solid #c9ad6a;
 }
 
-#users-glyph {
-    border:2px solid #777;
-    border-radius:10px;
-    padding:0px 3px;
-    border-top:none;
-    border-bottom:none;
-}
-
 .container ul.nav-tabs {
     margin-bottom:10px;
 }

--- a/static_files/style.css
+++ b/static_files/style.css
@@ -154,7 +154,7 @@ body {
     margin-bottom:10px;
 }
 
-ul.nav-tabs li:not(.delete-li) span.glyphicon {
+ul.nav-tabs li:not(.delete-li) span.fas {
     color: #000 !important;
 }
 
@@ -243,7 +243,7 @@ ul.nav-tabs li:not(.delete-li) span.glyphicon {
     color:#ab0000;
 }
 
-#finalize-btn a span.glyphicon {
+#finalize-btn a span.fas {
     color:#ab0000 !important;
 }
 


### PR DESCRIPTION
in preparation for the transition to Bootstrap 4, this commit removes
all traces of glyphicons and instead uses fontawesome 5.

there is a slight problem with SMDE, as it still includes fa 4.7 and
does not work correctly with fa5 only. this is tracked in #28.