### PR TITLE
Improve Markdown Editor

### DIFF
--- a/app/templates/sidebars.js
+++ b/app/templates/sidebars.js
@@ -338,10 +338,6 @@ function toggleMediaUploader(editor) {
     media_uploader.open_modal();
 }
 
-$("#media_upload").click(function() {
-    m.open_modal();
-});
-
 var reference = {
     name: "insertReference",
     action: toggleIntRefSidebar,
@@ -377,8 +373,15 @@ function generateMarkdownConfig(id, withHeading=true) {
         toolb = ["bold", "italic", "|", "unordered-list", "ordered-list", "|", "link", "image", "table", "horizontal-rule", "|", "side-by-side", "fullscreen", "guide", "|", reference, media, maps, upload];
     }
 
+    var previewClasses = ["custom-markdown"];
+
+    {% if current_user.markdown_phb_style == True %}
+    previewClasses.push("phb-style")
+    {% endif %}
+
     return {
         element: document.getElementById(id),
+        previewClass: previewClasses,
         toolbar: toolb,
         spellChecker: false,
         status: false,
@@ -387,7 +390,8 @@ function generateMarkdownConfig(id, withHeading=true) {
         onToggleFullScreen: function(fullscreen) {
             // hide navbar when going fullscreen
             $("#topnav").toggle(!fullscreen);
-        }
+        },
+        promptURLs: true
     }
 }
 

--- a/app/templates/sidebars.js
+++ b/app/templates/sidebars.js
@@ -383,7 +383,11 @@ function generateMarkdownConfig(id, withHeading=true) {
         spellChecker: false,
         status: false,
         autoDownloadFontAwesome: false,
-        minHeight: '{{ current_user.editor_height }}px'
+        minHeight: '{{ current_user.editor_height }}px',
+        onToggleFullScreen: function(fullscreen) {
+            // hide navbar when going fullscreen
+            $("#topnav").toggle(!fullscreen);
+        }
     }
 }
 


### PR DESCRIPTION
- Fix fullscreen with Bootstrap 4 (closes #42 again)

- Add our markdown classes to preview window
This makes for a better preview, but is NOT actually true to what the markdown will end up look like. I experimented around with a custom preview function that renders the markdown serverside, but due to the potential strain on the server (it is called after every keypress, could be alleviated with a delay / rate limit) and other factors decided against it. Could be implemented later.

