### PR TITLE
Fix docker uid

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+docker-compose.yml
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ WORKDIR /home/dungeonmaster
 
 # util-linux for uuidgen, rest for Pillow
 RUN apk update && \
-    apk add --no-cache jpeg util-linux zlib
+    apk add --no-cache gnupg jpeg su-exec util-linux shadow zlib
 
 RUN pip install --upgrade pip && pip install gunicorn
 
@@ -49,9 +49,7 @@ COPY --chown=dungeonmaster:dungeonmaster migrations ./migrations
 COPY --chown=dungeonmaster:dungeonmaster tests ./tests
 COPY --chown=dungeonmaster:dungeonmaster dmcp.py entrypoint.sh CHANGELOG.md run_tests.py ./
 
-USER dungeonmaster
-
-RUN chmod u+x entrypoint.sh
+RUN chmod +x entrypoint.sh
 
 ENV FLASK_APP dmcp.py
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,21 @@ RUN apk update && \
 # lint with flake8
 RUN pip install --upgrade pip
 RUN pip install flake8
-COPY . /usr/src/archivar-build/
+
+WORKDIR /usr/src/archivar-build
+
+# don't just copy . here, because then the build takes longer when changing
+# stuff like entrypoint.sh
+COPY app ./app
+COPY config ./config
+COPY install ./install
+COPY migrations ./migrations
+COPY tests ./tests
+COPY dmcp.py run_tests.py requirements.txt .flake8 ./
+
 RUN flake8 --config=.flake8
 
-RUN pip wheel --no-cache-dir --no-deps --wheel-dir /usr/src/archivar-build/wheels -r requirements.txt
+RUN pip wheel --no-cache-dir --no-deps --wheel-dir ./wheels -r requirements.txt
 
 ########
 # Image

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,6 +18,7 @@ sudo docker build -t archivar:latest .
 ### Run the Docker container
 Archivar needs a mount where it stores user data (and the database) under the mountpoint `/opt/data/`.
 Other configuration can be done via environment variables, see [config/README.md](config/README.md).
+If the volume directory is owned by a user with uid != 1000, you can override the uid of the internal user in the environment-block using USER_ID=$my-id.
 
 Example docker-compose file:
 


### PR DESCRIPTION
Allow the user to override the uid of the 'dungeonmaster' user inside
the docker container using the environment variable USER_ID=...

This results in several changes to the structure of the Dockerfile and
entrypoint.sh:
- remove USER directive in dockerfile, meaning we enter entrypoint.sh as
root
- (if necessary) change the uid of dungeonmaster and re-chown the
homedir
- all commands inside the entrypoint are now executed with su-exec,
which runs them as dungeonmaster.
- check that the dungeonmaster-user is the owner of the /opt/data mount,
error otherwise.

Closes #99.