### PR TITLE
Event: fix end date calculation error

### DIFF
--- a/app/event/models.py
+++ b/app/event/models.py
@@ -113,7 +113,7 @@ class Event(db.Model, SimplePermissionChecker, LinkGenerator):
         month_idx = -1
 
         for i, m in enumerate(months):
-            if days_into_year < m.days_before:
+            if days_into_year <= m.days_before:
                 month_idx = max(0, i - 1)
                 break
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argparse
 import unittest
 import sys

--- a/tests/models/test_event_model.py
+++ b/tests/models/test_event_model.py
@@ -99,8 +99,12 @@ class EventModelTest(BaseTestCase):
         event_skip_two_epochs = Event(epoch_id=self.epochs[0].id, year=1, month_id=self.months[0].id, day=1,
                                       duration=100*301+15)
 
+        # re-test for bug #119, let an event end at the last day of a month
+        event_last_of_month = Event(epoch_id=self.epochs[0].id, year=1, month_id=self.months[0].id, day=8, duration=2)
+
         self.add_all([event_month, event_year, event_month_year, event_epoch,
-                      event_month_epoch, event_month_year_epoch, event_skip_two_epochs])
+                      event_month_epoch, event_month_year_epoch, event_skip_two_epochs,
+                      event_last_of_month])
         self.commit()
 
         update_timestamp(event_month.id)
@@ -110,6 +114,7 @@ class EventModelTest(BaseTestCase):
         update_timestamp(event_month_epoch.id)
         update_timestamp(event_month_year_epoch.id)
         update_timestamp(event_skip_two_epochs.id)
+        update_timestamp(event_last_of_month.id)
 
         self.assertEqual(event_month.end_date(use_abbr=False), "6. Month 2 1, Epoch 1")
         self.assertEqual(event_year.end_date(use_abbr=False), "6. Month 1 2, Epoch 1")
@@ -118,6 +123,9 @@ class EventModelTest(BaseTestCase):
         self.assertEqual(event_month_epoch.end_date(use_abbr=False), "6. Month 2 1, Epoch 2")
         self.assertEqual(event_month_year_epoch.end_date(use_abbr=False), "6. Month 2 2, Epoch 2")
         self.assertEqual(event_skip_two_epochs.end_date(use_abbr=False), "6. Month 2 2, Epoch 3")
+
+        # bug #119, this would show "0. Month 2" before
+        self.assertEqual(event_last_of_month.end_date(use_abbr=False), "10. Month 1 1, Epoch 1")
 
     def test_day_of_the_week(self, app, client):
         # with static timestamp


### PR DESCRIPTION
fix off-by-one error if end date was the last day of a month. this would
lead to displays like "0th of month x+1" instead of "25th of month x".

Closes #119 

Signed-off-by: Thorben Römer <thorbenroemer@t-online.de>